### PR TITLE
Fixes for the npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5676,13 +5676,10 @@
 			"dev": true
 		},
 		"node_modules/ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
 		},
 		"node_modules/interpret": {
 			"version": "1.4.0",
@@ -13087,9 +13084,9 @@
 			}
 		},
 		"node_modules/y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"node_modules/yallist": {
@@ -17766,9 +17763,9 @@
 			"dev": true
 		},
 		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
 		},
 		"interpret": {
@@ -23654,9 +23651,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yallist": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
 	"version": "2.0.15",
 	"module": "dist/index.es.js",
 	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/j2inn/haystack-core"
+	},
 	"scripts": {
 		"watch": "nodemon --ext ts --ignore dist/ --ignore build/ --exec \"npm run lint && npm run test && npm run build\"",
 		"lint": "eslint --ext .ts .",
@@ -32,8 +37,7 @@
 		"prepack": "npm run lint && npm test && npm run build"
 	},
 	"files": [
-		"dist/**/*",
-		"src/**/*"
+		"dist/**/*"
 	],
 	"config": {
 		"unsafe-perm": true


### PR DESCRIPTION
Fix `package.json` to include the type declaration, include the repo URL, and remove the source code.

This comes from the https://www.skypack.dev/view/haystack-core check the `Package score` section and the linting details.

Solutions such as `skypack` allow inclusion of the package directly in websites or a Deno project without requiring `npm`.