### PR TITLE
Add implied tagging

### DIFF
--- a/spec/core/files/defs.trio
+++ b/spec/core/files/defs.trio
@@ -5663,3 +5663,4 @@ doc:Low power wireless communication protocol for home automation
 is:[^protocol]
 lib:^lib:phIct
 wikipedia:`https://en.wikipedia.org/wiki/Z-Wave`
+---

--- a/spec/filter/GenerateHaystackFilterImpliedVisitor.spec.ts
+++ b/spec/filter/GenerateHaystackFilterImpliedVisitor.spec.ts
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2019, J2 Innovations. All Rights Reserved
+ */
+
+import { HFilter } from '../../src/filter/HFilter'
+import { GenerateHaystackFilterImpliedVisitor } from '../../src/filter/GenerateHaystackFilterImpliedVisitor'
+import { readFile } from '../core/file'
+import { TrioReader } from '../../src/core/TrioReader'
+import { HNamespace } from '../../src/core/HNamespace'
+import { HDict } from '../../src/core/HDict'
+import { HSymbol } from '../../src/core/HSymbol'
+import { HList } from '../../src/core/HList'
+
+describe('GenerateHaystackFilterImpliedVisitor', function (): void {
+	let impliedTag: HDict
+	let namespace: HNamespace
+
+	beforeEach(function (): void {
+		let trio = readFile('./defs.trio')
+		trio += `
+---
+def:^lib:impliedTest
+doc:Implied tag lib experiment
+is:[^lib]
+lib:^lib:impliedTest
+version:"3.9.10"
+---
+def: ^impliedBy
+is: [^association]
+tagOn: ^def
+lib:^lib:impliedTest
+---
+def:^impliedTag
+doc: "An implied tag"
+is:[^entity]
+lib:^lib:impliedTest
+impliedBy: [^site]
+---`.trim()
+
+		const grid = new TrioReader(trio).readGrid()
+
+		namespace = new HNamespace(grid)
+		impliedTag = namespace.byName('impliedTag') as HDict
+	})
+
+	function parseAndGenerate(filter: string): string {
+		const visitor = new GenerateHaystackFilterImpliedVisitor(namespace)
+		HFilter.parse(filter).accept(visitor)
+		return visitor.filter
+	}
+
+	describe('#visitHas()', function (): void {
+		it('does not convert anything', function (): void {
+			expect(parseAndGenerate('site')).toBe('site')
+		})
+
+		it('converts a has from one tag to another', function (): void {
+			expect(parseAndGenerate('impliedTag')).toBe('(impliedTag or site)')
+		})
+
+		it('converts a has from two tags to another', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('site'), HSymbol.make('zone')])
+			)
+			expect(parseAndGenerate('impliedTag')).toBe(
+				'(impliedTag or (site and zone))'
+			)
+		})
+
+		it('converts a has with a path and one tag', function (): void {
+			impliedTag.set('impliedBy', new HList(HSymbol.make('siteRef')))
+
+			expect(parseAndGenerate('impliedTag->id')).toBe(
+				'(impliedTag->id or siteRef->id)'
+			)
+		})
+
+		it('converts a has with a path and two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('siteRef'), HSymbol.make('zone')])
+			)
+
+			expect(parseAndGenerate('impliedTag->id')).toBe(
+				'(impliedTag->id or (siteRef->id and zone))'
+			)
+		})
+
+		it('converts two layers of implied tags', function (): void {
+			impliedTag.set('impliedBy', new HList(HSymbol.make('siteRef')))
+
+			expect(parseAndGenerate('impliedTag->impliedTag->id')).toBe(
+				'((impliedTag->impliedTag->id or siteRef->impliedTag->id) or impliedTag->siteRef->id)'
+			)
+		})
+
+		it('converts two layers of implied tags with two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('siteRef'), HSymbol.make('zone')])
+			)
+
+			expect(parseAndGenerate('impliedTag->impliedTag->id')).toBe(
+				'((impliedTag->impliedTag->id or (siteRef->impliedTag->id and zone)) or (impliedTag->siteRef->id and impliedTag->zone))'
+			)
+		})
+	}) // #visitHas()
+
+	describe('#visitMissing()', function (): void {
+		it('does not convert anything', function (): void {
+			expect(parseAndGenerate('not site')).toBe('not site')
+		})
+
+		it('converts a not from one tag to another', function (): void {
+			expect(parseAndGenerate('not impliedTag')).toBe(
+				'(not impliedTag or not site)'
+			)
+		})
+
+		it('converts a not from two tags to another', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('site'), HSymbol.make('zone')])
+			)
+			expect(parseAndGenerate('not impliedTag')).toBe(
+				'(not impliedTag or (not site and not zone))'
+			)
+		})
+
+		it('converts a not with a path and one tag', function (): void {
+			impliedTag.set('impliedBy', new HList(HSymbol.make('siteRef')))
+
+			expect(parseAndGenerate('not impliedTag->id')).toBe(
+				'(not impliedTag->id or not siteRef->id)'
+			)
+		})
+
+		it('converts a not with a path and two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('siteRef'), HSymbol.make('zone')])
+			)
+
+			expect(parseAndGenerate('not impliedTag->id')).toBe(
+				'(not impliedTag->id or (not siteRef->id and not zone))'
+			)
+		})
+
+		it('converts two layers of implied tags', function (): void {
+			impliedTag.set('impliedBy', new HList(HSymbol.make('siteRef')))
+
+			expect(parseAndGenerate('not impliedTag->impliedTag->id')).toBe(
+				'((not impliedTag->impliedTag->id or not siteRef->impliedTag->id) or not impliedTag->siteRef->id)'
+			)
+		})
+
+		it('converts two layers of implied tags with two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('siteRef'), HSymbol.make('zone')])
+			)
+
+			expect(parseAndGenerate('not impliedTag->impliedTag->id')).toBe(
+				'((not impliedTag->impliedTag->id or (not siteRef->impliedTag->id and not zone)) or (not impliedTag->siteRef->id and not impliedTag->zone))'
+			)
+		})
+	}) // #visitMissing()
+
+	describe('#visitCmp()', function (): void {
+		it('does not convert anything', function (): void {
+			expect(parseAndGenerate('site == "test"')).toBe('site == "test"')
+		})
+
+		it('creates a value comparison with one tag', function (): void {
+			expect(parseAndGenerate('impliedTag == "foo"')).toBe(
+				'(impliedTag == "foo" or site == "foo")'
+			)
+		})
+
+		it('converts a value comparsion with two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('site'), HSymbol.make('zone')])
+			)
+			expect(parseAndGenerate('impliedTag == "test"')).toBe(
+				'(impliedTag == "test" or (site == "test" and zone))'
+			)
+		})
+
+		it('converts a value comparison with a path and one tag', function (): void {
+			impliedTag.set('impliedBy', new HList(HSymbol.make('siteRef')))
+
+			expect(parseAndGenerate('impliedTag->id == "test"')).toBe(
+				'(impliedTag->id == "test" or siteRef->id == "test")'
+			)
+		})
+
+		it('converts a value comparison with a path and two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('siteRef'), HSymbol.make('zone')])
+			)
+
+			expect(parseAndGenerate('impliedTag->id == "test"')).toBe(
+				'(impliedTag->id == "test" or (siteRef->id == "test" and zone))'
+			)
+		})
+
+		it('converts a value comparison with two layers of implied tags', function (): void {
+			impliedTag.set('impliedBy', new HList(HSymbol.make('siteRef')))
+
+			expect(
+				parseAndGenerate('impliedTag->impliedTag->id == "test"')
+			).toBe(
+				'((impliedTag->impliedTag->id == "test" or siteRef->impliedTag->id == "test") or impliedTag->siteRef->id == "test")'
+			)
+		})
+
+		it('converts a value comparison with two layers of implied tags with two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('siteRef'), HSymbol.make('zone')])
+			)
+
+			expect(
+				parseAndGenerate('impliedTag->impliedTag->id == "test"')
+			).toBe(
+				'((impliedTag->impliedTag->id == "test" or (siteRef->impliedTag->id == "test" and zone)) or (impliedTag->siteRef->id == "test" and impliedTag->zone))'
+			)
+		})
+	}) // #visitCmp()
+
+	describe('#visitIsA()', function (): void {
+		it('converts an `is a` query into a implied has', function (): void {
+			expect(parseAndGenerate('^impliedTag')).toBe(
+				'(^impliedTag or (impliedTag or site))'
+			)
+		})
+
+		it('converts an `is a` query in a large has query', function (): void {
+			expect(parseAndGenerate('^geoPlace')).toBe(
+				'(^geoPlace or (geoPlace or site or weatherStation))'
+			)
+		})
+	}) // #visitIsA()
+
+	describe('#visitRelationship()', function (): void {
+		it('does not convert anything', function (): void {
+			expect(parseAndGenerate('containedBy?')).toBe('containedBy?')
+		})
+
+		it('does not convert anything with a ref', function (): void {
+			expect(parseAndGenerate('containedBy? @foo')).toBe(
+				'containedBy? @foo'
+			)
+		})
+
+		it('creates a relationship query with one tag', function (): void {
+			expect(parseAndGenerate('impliedTag?')).toBe(
+				'(impliedTag? or site?)'
+			)
+		})
+
+		it('creates a relationship query with one tag, a ref and a term', function (): void {
+			expect(parseAndGenerate('impliedTag-elec? @foo')).toBe(
+				'(impliedTag-elec? @foo or site-elec? @foo)'
+			)
+		})
+
+		it('creates a relationship query with one tag and a ref', function (): void {
+			expect(parseAndGenerate('impliedTag? @foo')).toBe(
+				'(impliedTag? @foo or site? @foo)'
+			)
+		})
+
+		it('converts a relationship query with two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('site'), HSymbol.make('zone')])
+			)
+			expect(parseAndGenerate('impliedTag?')).toBe(
+				'(impliedTag? or (site? and zone))'
+			)
+		})
+
+		it('converts a relationship query with two tags and a ref', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('site'), HSymbol.make('zone')])
+			)
+			expect(parseAndGenerate('impliedTag? @foo')).toBe(
+				'(impliedTag? @foo or (site? @foo and zone))'
+			)
+		})
+
+		it('converts a relationship query with two tags, a ref and a term', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('site'), HSymbol.make('zone')])
+			)
+			expect(parseAndGenerate('impliedTag-elec? @foo')).toBe(
+				'(impliedTag-elec? @foo or (site-elec? @foo and zone))'
+			)
+		})
+	}) // #visitRelationship()
+
+	describe('#visitWildcardEquals()', function (): void {
+		it('does not convert anything', function (): void {
+			expect(parseAndGenerate('site *== @test')).toBe('site *== @test')
+		})
+
+		it('creates a wildcard equals with one tag', function (): void {
+			expect(parseAndGenerate('impliedTag *== @foo')).toBe(
+				'(impliedTag *== @foo or site *== @foo)'
+			)
+		})
+
+		it('converts a value comparsion with two tags', function (): void {
+			impliedTag.set(
+				'impliedBy',
+				new HList([HSymbol.make('site'), HSymbol.make('zone')])
+			)
+			expect(parseAndGenerate('impliedTag *== @test')).toBe(
+				'(impliedTag *== @test or (site *== @test and zone))'
+			)
+		})
+	}) // #visitWildcardEquals()
+}) // GenerateHaystackFilterImpliedVisitor

--- a/src/core/HNamespace.ts
+++ b/src/core/HNamespace.ts
@@ -13,6 +13,7 @@ import { ZincReader } from './ZincReader'
 import { valueIsKind, OptionalHVal } from './HVal'
 import { HMarker } from './HMarker'
 import { HRef } from './HRef'
+import { IMPLIED_BY } from './util'
 
 export interface Defs {
 	[prop: string]: HDict
@@ -1299,5 +1300,85 @@ export class HNamespace {
 		}
 
 		return false
+	}
+
+	/**
+	 * Returns a new dict with any implied tags that don't already exist on the dict.
+	 *
+	 * @param dict The dict to look up the implied tags on.
+	 * @returns An implied tag dict.
+	 */
+	public toImplied(dict: HDict): HDict {
+		const impliedDict = new HDict()
+		const impliedDefs = this.impliedDefs
+
+		for (const key of dict.keys) {
+			const defs = impliedDefs[key]
+
+			if (defs && defs.length) {
+				for (const def of defs) {
+					// Check the dict doesn't already have the implied tag.
+					if (!dict.has(def.defName)) {
+						// Test to see if dict has all the tags necessary for the implied tag.
+						const impliedBy = def.get<HList<HSymbol>>(IMPLIED_BY)
+
+						if (impliedBy && this.isImpliedMatch(dict, impliedBy)) {
+							const value = dict.get(impliedBy[0]?.value)
+
+							if (value && !impliedDict.has(def.defName)) {
+								impliedDict.set(def.defName, value.newCopy())
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return impliedDict
+	}
+
+	/**
+	 * Return true if the dict has all of the tags.
+	 *
+	 * @param dict The dict to test.
+	 * @param impliedBy A list of tag names to test.
+	 * @returns True if the dict has all of the tags.
+	 */
+	private isImpliedMatch(dict: HDict, impliedBy: HList<HSymbol>): boolean {
+		let matches = !impliedBy.isEmpty()
+
+		for (const tag of impliedBy) {
+			if (!dict.has(tag.value)) {
+				matches = false
+				break
+			}
+		}
+
+		return matches
+	}
+
+	/**
+	 * @returns A map of a tags to defs that have implied rules.
+	 * This map is used to quickly look up tags that are connected with any implied rules.
+	 */
+	@memoize()
+	private get impliedDefs(): NameToDefs {
+		const impliedDefs: NameToDefs = {}
+
+		for (const name of Object.keys(this.defs)) {
+			const def = this.byName(name) as HDict
+			const implied = def?.get(IMPLIED_BY)
+
+			if (valueIsKind<HList<HSymbol>>(implied, Kind.List)) {
+				for (const symbol of implied) {
+					const dicts: HDict[] = (impliedDefs[symbol.value] =
+						impliedDefs[symbol.value] ?? [])
+
+					dicts.push(def)
+				}
+			}
+		}
+
+		return impliedDefs
 	}
 }

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -244,3 +244,8 @@ export function toTagName(name: string): string {
 export function isValidTagName(name: string): boolean {
 	return /^[a-z][a-zA-Z0-9_]+$/.test(String(name))
 }
+
+/**
+ * The implied by tag name.
+ */
+export const IMPLIED_BY = 'impliedBy'

--- a/src/filter/GenerateHaystackFilterImpliedVisitor.ts
+++ b/src/filter/GenerateHaystackFilterImpliedVisitor.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2021, J2 Innovations. All Rights Reserved
+ */
+
+import { Kind } from '../core/Kind'
+import { HList } from '../core/HList'
+import { HSymbol } from '../core/HSymbol'
+import { HNamespace } from '../core/HNamespace'
+import { HDict } from '../core/HDict'
+import { GenerateHaystackFilterVisitor } from './GenerateHaystackFilterVisitor'
+import {
+	HasNode,
+	MissingNode,
+	CmpNode,
+	IsANode,
+	RelationshipNode,
+	WildcardEqualsNode,
+} from './Node'
+import { TokenPaths } from './TokenPaths'
+import { valueIsKind } from '../core/HVal'
+import { GenerateHaystackFilterV3Visitor } from './GenerateHaystackFilterV3Visitor'
+import { HFilter } from './HFilter'
+import { IMPLIED_BY } from '../core/util'
+
+/**
+ * Generates a Haystack Filter String by processing any implied tags rules.
+ *
+ * For instance, a haystack filter that uses implied tags can query a database
+ * that contains records without the implied tags present.
+ *
+ * Warning: implied tags are currently considered experimental.
+ */
+export class GenerateHaystackFilterImpliedVisitor extends GenerateHaystackFilterVisitor {
+	/**
+	 * The readonly namespace.
+	 */
+	readonly #namespace: HNamespace
+
+	/**
+	 * The implied tags to look up.
+	 *
+	 * @param namespace The namespace used to query implied tags.
+	 */
+	public constructor(namespace: HNamespace) {
+		super()
+		this.#namespace = namespace
+	}
+
+	public visitHas(node: HasNode): void {
+		let filter = node.path.toFilter()
+		const paths = node.path.paths
+
+		for (let i = 0; i < paths.length; ++i) {
+			const impliedFilter = this.replaceImpliedTags(paths, i)
+
+			if (impliedFilter) {
+				filter = `(${filter} or ${impliedFilter})`
+			}
+		}
+
+		this.append(filter)
+	}
+
+	public visitMissing(node: MissingNode): void {
+		let filter = `not ${node.path.toFilter()}`
+		const paths = node.path.paths
+
+		for (let i = 0; i < paths.length; ++i) {
+			const impliedFilter = this.replaceImpliedTags(paths, i, 'not ')
+
+			if (impliedFilter) {
+				filter = `(${filter} or ${impliedFilter})`
+			}
+		}
+
+		this.append(filter)
+	}
+
+	public visitCmp(node: CmpNode): void {
+		const paths = node.path.paths
+		const valuePostfix = ` ${node.cmpOp.text} ${node.val.toFilter()}`
+
+		let filter = `${node.path.toFilter()}${valuePostfix}`
+
+		for (let i = 0; i < paths.length; ++i) {
+			const impliedFilter = this.replaceImpliedTags(
+				paths,
+				i,
+				'',
+				valuePostfix
+			)
+
+			if (impliedFilter) {
+				filter = `(${filter} or ${impliedFilter})`
+			}
+		}
+
+		this.append(filter)
+	}
+
+	public visitIsA(node: IsANode): void {
+		const filter = node.val.toFilter()
+
+		// Convert the is a query to a large `has` query using Haystack v4 to v3 transpilation.
+		const v3Node = HFilter.parse(filter)
+		const v3Visitor = new GenerateHaystackFilterV3Visitor(this.#namespace)
+		v3Node.accept(v3Visitor)
+		const hasFilter = v3Visitor.filter
+
+		// Now convert from the large `has` query into an implied filter check.
+		// using an instance of this filter.
+		const hasNode = HFilter.parse(hasFilter)
+		const impliedVisitor = new GenerateHaystackFilterImpliedVisitor(
+			this.#namespace
+		)
+		hasNode.accept(impliedVisitor)
+
+		this.append(`(${filter} or ${impliedVisitor.filter})`)
+	}
+
+	public visitRelationship(node: RelationshipNode): void {
+		const relationship = node.rel.relationship
+		const valuePostfix = `${node.rel.term ? `-${node.rel.term}` : ''}?${
+			node.ref ? ` ${node.ref.toFilter()}` : ''
+		}`
+
+		let filter = node.rel.toFilter()
+		if (node.ref) {
+			filter += ` ${node.ref.toFilter()}`
+		}
+
+		const impliedFilter = this.replaceImpliedTags(
+			[relationship],
+			0,
+			'',
+			valuePostfix
+		)
+
+		if (impliedFilter) {
+			filter = `(${filter} or ${impliedFilter})`
+		}
+
+		this.append(filter)
+	}
+
+	public visitWildcardEquals(node: WildcardEqualsNode): void {
+		const id = node.id.toFilter()
+		const valuePostfix = ` *== ${node.ref.toFilter()}`
+
+		let filter = `${id}${valuePostfix}`
+
+		const impliedFilter = this.replaceImpliedTags([id], 0, '', valuePostfix)
+
+		if (impliedFilter) {
+			filter = `(${filter} or ${impliedFilter})`
+		}
+
+		this.append(filter)
+	}
+
+	/**
+	 * Replace any implied tags with the necessary rules and values.
+	 *
+	 * @param paths The paths to the value being tested.
+	 * @param index The current index of the path.
+	 * @param prefix Any prefix to add before each path.
+	 * @param valuePostfix Any postfix to include after the value.
+	 * @returns The updated filter.
+	 */
+	private replaceImpliedTags(
+		paths: string[],
+		index: number,
+		prefix = '',
+		valuePostFix = ''
+	): string {
+		let filter = ''
+
+		const path = paths[index]
+		const impliedBy = this.getImpliedBy(this.#namespace.byName(path))
+
+		if (impliedBy.length) {
+			filter =
+				prefix +
+					impliedBy
+						?.map((symbol, i) => {
+							const newPaths = [...paths]
+							newPaths[index] = symbol
+							if (i > 0) {
+								newPaths.splice(index + 1, newPaths.length)
+							}
+							let newFilter = new TokenPaths(newPaths).toFilter()
+							if (i === 0) {
+								newFilter = `${newFilter}${valuePostFix}`
+							}
+							return newFilter
+						})
+						.join(` and ${prefix}`) ?? path
+
+			if (impliedBy.length > 1) {
+				filter = `(${filter})`
+			}
+		}
+
+		return filter
+	}
+
+	/**
+	 * Returns a list of tags to imply the rule against.
+	 *
+	 * @param def The def to test.
+	 * @returns An array of tag names.
+	 */
+	private getImpliedBy(def: HDict | undefined): string[] {
+		const impliedBy = def?.get(IMPLIED_BY)
+
+		return valueIsKind<HList<HSymbol>>(impliedBy, Kind.List)
+			? impliedBy.map((symbol) => symbol.value)
+			: []
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 // Filter
 export * from './filter/HFilter'
 export * from './filter/GenerateHaystackFilterVisitor'
+export * from './filter/GenerateHaystackFilterImpliedVisitor'
 export * from './filter/GenerateHaystackFilterV3Visitor'
 export * from './filter/EvalContext'
 export * from './filter/Node'


### PR DESCRIPTION
This is an experimental feature for implied tags as spoken in our design review yesterday. 

A def that wants to use implied tags declares an impliedBy tag...

```
def:^sieBuilding
is:[^marker]
impliedBy: [^site]
```

Therefore, if a record has `site`, the rule states it'll also have `sieBuilding`.

Multiple tags can be used to extend the rule. For example...

```
def:^sieBuilding
is:[^marker]
impliedBy: [^site, ^zone]
```
In this case both the `site` and `zone` tags must be present in order for the `sieBuilding` tag to be added.

Values can be implied by specifying the first tag in the list. For example...

```
def:^sieBuildingRef
...
impliedBy: [^siteRef, ^site]
```

In this case, the `sieBuildingRef` is implied by the record having both the `siteRef` and `site` tags. The value for `sieBuildingRef` is `siteRef`.
