### PR TITLE
Fix grid JSON decoding for comparisons

### DIFF
--- a/spec/core/HGrid.spec.ts
+++ b/spec/core/HGrid.spec.ts
@@ -4,7 +4,12 @@
 
 /* eslint @typescript-eslint/no-explicit-any: "off" */
 
-import { HGrid, DEFAULT_GRID_VERSION, GridColumn } from '../../src/core/HGrid'
+import {
+	HGrid,
+	DEFAULT_GRID_VERSION,
+	GridColumn,
+	GRID_VERSION_NAME,
+} from '../../src/core/HGrid'
 import { HDict } from '../../src/core/HDict'
 import { HStr } from '../../src/core/HStr'
 import { Kind } from '../../src/core/Kind'
@@ -246,6 +251,24 @@ describe('HGrid', function (): void {
 				const newGrid = new HGrid([dict])
 
 				expect(new HGrid([hayson])).toValEqual(newGrid)
+			})
+
+			it('creates a grid from hayson and ensures the version is removed from the meta', function (): void {
+				const grid = new HGrid({
+					rows: [
+						new HDict({ id: HRef.make('a'), dis: 'a display' }),
+						new HDict({ id: HRef.make('b'), dis: 'b display' }),
+					],
+				})
+
+				const gridJson = grid.toJSON()
+
+				expect(gridJson?.meta?.ver).toBe(DEFAULT_GRID_VERSION)
+
+				const decodedGrid = new HGrid(gridJson)
+
+				expect(decodedGrid.equals(grid)).toBe(true)
+				expect(decodedGrid.meta.has(GRID_VERSION_NAME)).toBe(false)
 			})
 		}) // #constructor()
 

--- a/spec/core/Util.spec.ts
+++ b/spec/core/Util.spec.ts
@@ -217,6 +217,24 @@ describe('util', function (): void {
 		it('returns null for a null value', function (): void {
 			expect(makeValue(null)).toBeNull()
 		})
+
+		it("encodes a grid to JSON and then decodes it ensuring it's still the same", function (): void {
+			// This use case covers how a
+			const grid = new HGrid({
+				rows: [
+					new HDict({ id: HRef.make('a'), dis: 'a display' }),
+					new HDict({ id: HRef.make('b'), dis: 'b display' }),
+				],
+			})
+
+			const gridStr = JSON.stringify(grid.toJSON())
+
+			const decodedGrid = makeValue(JSON.parse(gridStr)) as
+				| HGrid
+				| undefined
+
+			expect(decodedGrid?.equals(grid)).toBe(true)
+		})
 	}) // makeValue
 
 	describe('toTagName()', function (): void {


### PR DESCRIPTION
A Haystack JSON (Hayson) grid has ver in a grid’s meta. This causes an issue when decoding into an HGrid that keeps the ver data in the meta. This effectively breaks the comparison with a similar non-decoded JSON grid since one grid has ver in its meta and the other one doesn’t.

@rracariu do we need to also fix this in `libhaystack`?

For example…

```typescript
// This use case covers how a
const grid = new HGrid({
	rows: [
		new HDict({ id: HRef.make('a'), dis: 'a display' }),
		new HDict({ id: HRef.make('b'), dis: 'b display' }),
	],
})

const gridStr = JSON.stringify(grid.toJSON())

const decodedGrid = makeValue(JSON.parse(gridStr)) as
	| HGrid
	| undefined

// Returns false since one grid has `ver` in the meta and one doesn't.
return decodedGrid?.equals(grid)