### PR TITLE
Align shorthand functions signatures with the Objects ones.

### DIFF
--- a/spec/shorthand.spec.ts
+++ b/spec/shorthand.spec.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2020, J2 Innovations. All Rights Reserved
+ */
+
+import {
+	HCoord,
+	HDateTime,
+	HGrid,
+	HMarker,
+	HNa,
+	HNum,
+	HRef,
+	HRemove,
+	HStr,
+	HTime,
+	HUri,
+	HXStr,
+	Kind,
+} from '../src/index'
+import {
+	bool,
+	coord,
+	date,
+	dateTime,
+	dict,
+	grid,
+	list,
+	make,
+	num,
+	ref,
+	str,
+	symbol,
+	time,
+	uri,
+	xstr,
+} from '../src/shorthand'
+
+import { FALSE, MARKER, NA, REMOVE, TRUE } from './../src/shorthand'
+
+describe('shorthand', () => {
+	describe('make', () => {
+		it('makes bool', () => {
+			expect(make(true)?.valueOf()).toBe(true)
+			expect(make(false)?.valueOf()).toEqual(false)
+
+			expect(make(make(true))?.valueOf()).toBe(true)
+		})
+	}) // make
+
+	describe('bool', () => {
+		it('makes bool', () => {
+			expect(bool(true).value).toBe(true)
+			expect(bool(false).value).toEqual(false)
+
+			expect(bool(bool(true)).value).toBe(true)
+		})
+
+		it('constants', () => {
+			expect(TRUE.value).toBe(true)
+			expect(FALSE.value).toEqual(false)
+		})
+	}) // bool
+
+	describe('coord', () => {
+		it('makes coord', () => {
+			expect(coord({ lat: 1, lng: 2 }).toZinc()).toBe(
+				coord({ latitude: 1, longitude: 2 }).toZinc()
+			)
+
+			expect(coord(HCoord.make({ lat: 1, lng: 2 })).toJSON()).toEqual(
+				coord(coord({ latitude: 1, longitude: 2 })).toJSON()
+			)
+		})
+	}) // coord
+
+	describe('date', () => {
+		it('makes date', () => {
+			expect(date(new Date('2009-11-09T15:39:00Z')).value).toBe(
+				'2009-11-09'
+			)
+
+			expect(date(date({ year: 2022, month: 10, day: 10 })).value).toBe(
+				'2022-10-10'
+			)
+		})
+	}) // date
+
+	describe('dateTime', () => {
+		it('makes dateTime', () => {
+			expect(dateTime('2009-11-09T15:39:00Z').value).toEqual(
+				'2009-11-09T15:39:00Z'
+			)
+
+			expect(
+				dateTime({
+					_kind: Kind.DateTime,
+					val: '2010-11-28T07:23:02.773-08:00',
+					tz: 'Los_Angeles',
+				}).equals(
+					dateTime(
+						HDateTime.make(
+							'2010-11-28T07:23:02.773-08:00 Los_Angeles'
+						)
+					)
+				)
+			).toBe(true)
+		})
+	}) // dateTime
+
+	describe('symbol', () => {
+		it('makes symbol', () => {
+			expect(symbol('test').value).toEqual('test')
+
+			expect(symbol({ _kind: Kind.Symbol, val: 'test' }).value).toEqual(
+				'test'
+			)
+
+			expect(symbol(symbol('test')).value).toEqual('test')
+		})
+	}) // symbol
+
+	describe('dict', () => {
+		it('makes dict', () => {
+			expect(dict({}).toJSON()).toEqual({})
+
+			expect(dict({ foo: 'Test', bar: MARKER }).toJSON()).toEqual({
+				foo: 'Test',
+				bar: { _kind: Kind.Marker },
+			})
+
+			expect(dict(dict({ foo: 'Test', bar: MARKER })).toJSON()).toEqual(
+				dict({
+					foo: 'Test',
+					bar: { _kind: Kind.Marker },
+				}).toJSON()
+			)
+		})
+	}) // dict
+
+	describe('grid', () => {
+		it('makes grid', () => {
+			expect(grid([{}]).toJSON()).toEqual(new HGrid([{}]).toJSON())
+
+			expect(
+				grid({
+					cols: [{ name: 'foo' }],
+					rows: [{ foo: 'foo' }],
+				})
+			).toEqual(
+				new HGrid({
+					cols: [{ name: 'foo' }],
+					rows: [{ foo: 'foo' }],
+				})
+			)
+
+			expect(
+				grid(
+					grid({
+						cols: [{ name: 'foo' }],
+						rows: [{ foo: 'foo' }],
+					})
+				)
+			).toEqual(
+				new HGrid({
+					cols: [{ name: 'foo' }],
+					rows: [{ foo: 'foo' }],
+				})
+			)
+		})
+	}) // grid
+
+	describe('list', () => {
+		it('makes list', () => {
+			expect(list([{}]).toJSON()).toEqual([{}])
+
+			expect(list([MARKER, 'foo', symbol('foo')]).toJSON()).toEqual([
+				{ _kind: 'marker' },
+				'foo',
+				{ _kind: 'symbol', val: 'foo' },
+			])
+
+			expect(list(list([MARKER])).toJSON()).toEqual([{ _kind: 'marker' }])
+		})
+	}) // list
+
+	describe('MARKER', () => {
+		it('makes MARKER', () => {
+			expect(MARKER.toJSON()).toEqual({ _kind: 'marker' })
+
+			expect(MARKER).toStrictEqual(HMarker.make())
+		})
+	}) // MARKER
+
+	describe('NA', () => {
+		it('makes NA', () => {
+			expect(NA.toJSON()).toEqual({ _kind: 'na' })
+
+			expect(NA).toStrictEqual(HNa.make())
+		})
+	}) // NA
+
+	describe('REMOVE', () => {
+		it('makes REMOVE', () => {
+			expect(REMOVE.toJSON()).toEqual({ _kind: 'remove' })
+
+			expect(REMOVE).toStrictEqual(HRemove.make())
+		})
+	}) // REMOVE
+
+	describe('num', () => {
+		it('makes num', () => {
+			expect(num(100).value).toEqual(100)
+
+			expect(num(100, 's').toZinc()).toEqual('100s')
+
+			expect(num({ _kind: Kind.Number, val: 100, unit: 's' })).toEqual(
+				HNum.make(100, 's')
+			)
+
+			expect(num(num(100, 's')).toZinc()).toEqual('100s')
+		})
+	}) // num
+
+	describe('ref', () => {
+		it('makes ref', () => {
+			expect(ref('abc').value).toEqual('abc')
+
+			expect(ref({ _kind: Kind.Ref, val: 'abc' })).toEqual(
+				HRef.make('abc')
+			)
+
+			expect(ref(ref('foo')).toZinc()).toEqual('@foo')
+		})
+	}) // ref
+
+	describe('str', () => {
+		it('makes str', () => {
+			expect(str('abc').value).toEqual('abc')
+
+			expect(str(str('foo'))).toEqual(HStr.make('foo'))
+		})
+	}) // str
+
+	describe('time', () => {
+		it('makes time', () => {
+			expect(time(new Date('2009-11-09T15:39:00Z')).value).toEqual(
+				'15:39:00'
+			)
+
+			expect(
+				time({
+					hours: 12,
+					minutes: 1,
+					seconds: 2,
+				}).value
+			).toEqual('12:01:02')
+
+			expect(
+				time({
+					_kind: Kind.Time,
+					val: '12:01:02',
+				}).value
+			).toEqual('12:01:02')
+
+			expect(time(time('12:00:00'))).toEqual(HTime.make('12:00:00'))
+		})
+	}) // time
+
+	describe('uri', () => {
+		it('makes uri', () => {
+			expect(uri('abc').value).toEqual('abc')
+
+			expect(uri({ _kind: Kind.Uri, val: 'abc' })).toEqual(
+				HUri.make('abc')
+			)
+
+			expect(uri(uri('foo')).toZinc()).toEqual('`foo`')
+		})
+	}) // uri
+
+	describe('xstr', () => {
+		it('makes xstr', () => {
+			expect(xstr('foo', 'abc').value).toEqual('abc')
+
+			expect(xstr({ _kind: Kind.XStr, type: 'foo', val: 'abc' })).toEqual(
+				HXStr.make('foo', 'abc')
+			)
+
+			expect(xstr(xstr('foo')).toZinc()).toEqual('foo("")')
+		})
+	}) // uri
+})

--- a/src/core/HCoord.ts
+++ b/src/core/HCoord.ts
@@ -23,9 +23,6 @@ export interface CoordObj {
 	longitude: number
 }
 
-/** Accepted types for making a `HCoord` from */
-type CoordBaseType = CoordObj | HaysonCoord | HCoord
-
 /**
  * Haystack coord.
  */
@@ -83,7 +80,7 @@ export class HCoord implements HVal {
 	 * @returns A haystack coordinate.
 	 * @throws An error if the latitude or longitude are invalid.
 	 */
-	public static make(value: CoordBaseType): HCoord {
+	public static make(value: CoordObj | HaysonCoord | HCoord): HCoord {
 		if (valueIsKind<HCoord>(value, Kind.Coord)) {
 			return value
 		} else {

--- a/src/core/HDateTime.ts
+++ b/src/core/HDateTime.ts
@@ -26,9 +26,6 @@ export interface PartialHaysonDateTime {
 	tz?: string
 }
 
-/** Accepted types for making a `HDateTime` from */
-type DateTimeBaseType = string | Date | HaysonDateTime | HDateTime
-
 /**
  * Prefixes for IANA timezone names.
  */
@@ -172,7 +169,9 @@ export class HDateTime implements HVal {
 	 * @param value The date time as a string, a JS Date or Hayson date object.
 	 * @returns A haystack date time.
 	 */
-	public static make(value: DateTimeBaseType): HDateTime {
+	public static make(
+		value: string | Date | HaysonDateTime | HDateTime
+	): HDateTime {
 		if (valueIsKind<HDateTime>(value, Kind.DateTime)) {
 			return value
 		} else {

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -18,9 +18,6 @@ import { HDict } from './HDict'
 import { EvalContext } from '../filter/EvalContext'
 import { HUnit } from './HUnit'
 
-/** Accepted types for making a `HNum` from */
-type NumberBaseType = number | HaysonNum | HNum
-
 /**
  * The default numeric precision.
  */
@@ -79,7 +76,10 @@ export class HNum implements HVal {
 	 * @param unit Optional units.
 	 * @returns A haystack number.
 	 */
-	public static make(value: NumberBaseType, unit?: string | HUnit): HNum {
+	public static make(
+		value: number | HaysonNum | HNum,
+		unit?: string | HUnit
+	): HNum {
 		let val = 0
 		if (typeof value === 'number') {
 			val = value as number

--- a/src/core/HRef.ts
+++ b/src/core/HRef.ts
@@ -18,9 +18,6 @@ import { HList } from './HList'
 import { HDict } from './HDict'
 import { EvalContext } from '../filter/EvalContext'
 
-/** Accepted types for making a `HRef` from */
-type RefBaseType = string | HaysonRef | HRef | HStr
-
 /**
  * Haystack ref.
  */
@@ -69,7 +66,10 @@ export class HRef implements HVal {
 	 * @param displayName Optional display string for a reference.
 	 * @returns A haystack ref.
 	 */
-	public static make(value: RefBaseType, displayName?: string): HRef {
+	public static make(
+		value: string | HaysonRef | HRef | HStr,
+		displayName?: string
+	): HRef {
 		if (valueIsKind<HRef>(value, Kind.Ref)) {
 			return value
 		} else {

--- a/src/core/HSymbol.ts
+++ b/src/core/HSymbol.ts
@@ -23,9 +23,6 @@ export interface PartialHaysonSymbol {
 	val: string
 }
 
-/** Accepted types for making a `HSymbol` from */
-type SymbolBaseType = string | HaysonSymbol | HSymbol
-
 /**
  * Haystack symbol.
  */
@@ -50,7 +47,7 @@ export class HSymbol implements HVal {
 	 * @param value The value string or Hayson symbol object.
 	 * @returns A haystack symbol.
 	 */
-	public static make(value: SymbolBaseType): HSymbol {
+	public static make(value: string | HaysonSymbol | HSymbol): HSymbol {
 		if (valueIsKind<HSymbol>(value, Kind.Symbol)) {
 			return value
 		} else {

--- a/src/core/HTime.ts
+++ b/src/core/HTime.ts
@@ -27,9 +27,6 @@ export interface TimeObj {
 	milliseconds?: number
 }
 
-/** Accepted types for making a `HTime` from */
-type TimeBaseType = string | Date | TimeObj | HaysonTime | HTime
-
 /**
  * Haystack time.
  */
@@ -93,7 +90,9 @@ export class HTime implements HVal {
 	 * @param value The value.
 	 * @returns A haystack time.
 	 */
-	public static make(value: TimeBaseType): HTime {
+	public static make(
+		value: string | Date | TimeObj | HaysonTime | HTime
+	): HTime {
 		if (valueIsKind<HTime>(value, Kind.Time)) {
 			return value
 		} else {

--- a/src/core/HXStr.ts
+++ b/src/core/HXStr.ts
@@ -19,9 +19,6 @@ import { HDict } from './HDict'
 import { HStr } from './HStr'
 import { EvalContext } from '../filter/EvalContext'
 
-/** Accepted types for making a `HXStr` from */
-type XStrBaseType = string | HaysonXStr | HXStr
-
 /**
  * Haystack XStr.
  */
@@ -60,7 +57,10 @@ export class HXStr implements HVal {
 	 * @param value The value.
 	 * @returns A haystack xstring.
 	 */
-	public static make(type: XStrBaseType, value?: string): HXStr {
+	public static make(
+		type: string | HaysonXStr | HXStr,
+		value?: string
+	): HXStr {
 		if (valueIsKind<HXStr>(type, Kind.XStr)) {
 			return type
 		} else {

--- a/src/shorthand.ts
+++ b/src/shorthand.ts
@@ -2,45 +2,45 @@
  * Copyright (c) 2020, J2 Innovations. All Rights Reserved
  */
 
+import {
+	HaysonCoord,
+	HaysonDate,
+	HaysonDateTime,
+	HaysonDict,
+	HaysonGrid,
+	HaysonList,
+	HaysonNum,
+	HaysonRef,
+	HaysonSymbol,
+	HaysonTime,
+	HaysonUri,
+	HaysonVal,
+	HaysonXStr,
+} from './core/hayson'
 import { HBool } from './core/HBool'
-import { HCoord, CoordObj } from './core/HCoord'
-import { HDate, DateObj } from './core/HDate'
+import { CoordObj, HCoord } from './core/HCoord'
+import { DateObj, HDate } from './core/HDate'
 import { HDateTime } from './core/HDateTime'
-import { HSymbol } from './core/HSymbol'
-import { HDict, HValObj } from './core/HDict'
-import { HGrid, GridObj } from './core/HGrid'
+import { DictStore, HDict } from './core/HDict'
+import { HGrid } from './core/HGrid'
 import { HList } from './core/HList'
-import { HVal, OptionalHVal } from './core/HVal'
 import { HMarker } from './core/HMarker'
 import { HNa } from './core/HNa'
+import { HNamespace } from './core/HNamespace'
 import { HNum } from './core/HNum'
 import { HRef } from './core/HRef'
 import { HRemove } from './core/HRemove'
 import { HStr } from './core/HStr'
+import { HSymbol } from './core/HSymbol'
 import { HTime, TimeObj } from './core/HTime'
 import { HUri } from './core/HUri'
+import { HVal, OptionalHVal } from './core/HVal'
 import { HXStr } from './core/HXStr'
-import { ZincReader } from './core/ZincReader'
 import { TrioReader } from './core/TrioReader'
-import { HNamespace } from './core/HNamespace'
-import {
-	HaysonDate,
-	HaysonCoord,
-	HaysonDateTime,
-	HaysonSymbol,
-	HaysonGrid,
-	HaysonList,
-	HaysonVal,
-	HaysonNum,
-	HaysonTime,
-	HaysonUri,
-	HaysonXStr,
-	HaysonRef,
-	HaysonDict,
-} from './core/hayson'
+import { ZincReader } from './core/ZincReader'
 
-import { makeValue, toTagName, isValidTagName } from './core/util'
 import { HUnit } from './core/HUnit'
+import { isValidTagName, makeValue, toTagName } from './core/util'
 
 /**
  * Core Haystack utility shorthand functions.
@@ -52,40 +52,51 @@ import { HUnit } from './core/HUnit'
  * @module
  */
 
-export function bool(bool: boolean): HBool {
+export function bool(bool: boolean | HBool): HBool {
 	return HBool.make(bool)
 }
 
 export const TRUE = HBool.make(true)
 export const FALSE = HBool.make(false)
 
-export function coord(value: CoordObj | HaysonCoord): HCoord {
+export function coord(value: CoordObj | HaysonCoord | HCoord): HCoord {
 	return HCoord.make(value)
 }
 
-export function date(value: string | Date | DateObj | HaysonDate): HDate {
+export function date(
+	value: string | Date | DateObj | HaysonDate | HDate
+): HDate {
 	return HDate.make(value)
 }
 
-export function dateTime(value: string | Date | HaysonDateTime): HDateTime {
+export function dateTime(
+	value: string | Date | HaysonDateTime | HDateTime
+): HDateTime {
 	return HDateTime.make(value)
 }
 
-export function symbol(value: string | HaysonSymbol): HSymbol {
+export function symbol(value: string | HaysonSymbol | HSymbol): HSymbol {
 	return HSymbol.make(value)
 }
 
-export function dict(values?: HValObj | HaysonDict | HVal): HDict {
+export function dict(
+	values?:
+		| { [prop: string]: OptionalHVal | HaysonVal }
+		| OptionalHVal
+		| DictStore
+): HDict {
 	return HDict.make(values)
 }
 
-export function grid(values: GridObj | HaysonGrid | HVal): HGrid {
+export function grid(
+	values: HaysonGrid | HVal | (HaysonDict | HDict)[]
+): HGrid {
 	return HGrid.make(values)
 }
 
-export function list<T extends HVal>(
-	...values: (T | HaysonVal | T[] | HaysonList)[]
-): HList<T> {
+export function list<Value extends OptionalHVal = OptionalHVal>(
+	...values: (Value | HaysonVal | (Value | HaysonVal)[] | HaysonList)[]
+): HList<Value> {
 	return HList.make(...values)
 }
 
@@ -93,29 +104,34 @@ export const MARKER = HMarker.make()
 
 export const NA = HNa.make()
 
-export function num(value: number | HaysonNum, unit?: string): HNum {
+export const REMOVE = HRemove.make()
+
+export function num(value: number | HaysonNum | HNum, unit?: string): HNum {
 	return HNum.make(value, unit)
 }
 
-export function ref(value: string | HaysonRef, displayName?: string): HRef {
+export function ref(
+	value: string | HaysonRef | HRef | HStr,
+	displayName?: string
+): HRef {
 	return HRef.make(value, displayName)
 }
 
-export const REMOVE = HRemove.make()
-
-export function str(value: string): HStr {
+export function str(value: string | HStr): HStr {
 	return HStr.make(value)
 }
 
-export function time(value: string | Date | TimeObj | HaysonTime): HTime {
+export function time(
+	value: string | Date | TimeObj | HaysonTime | HTime
+): HTime {
 	return HTime.make(value)
 }
 
-export function uri(value: string | HaysonUri): HUri {
+export function uri(value: string | HaysonUri | HUri): HUri {
 	return HUri.make(value)
 }
 
-export function xstr(type: string | HaysonXStr, value?: string): HXStr {
+export function xstr(type: string | HaysonXStr | HXStr, value?: string): HXStr {
 	return HXStr.make(type, value)
 }
 
@@ -127,7 +143,7 @@ export function trio(input: string): HGrid | undefined {
 	return TrioReader.readGrid(input)
 }
 
-export function make(value: HaysonVal): OptionalHVal {
+export function make(value: HaysonVal | HVal | undefined): OptionalHVal {
 	return makeValue(value)
 }
 


### PR DESCRIPTION
Noticed that some of the function parameters type were not aligned to the main types constructor signatures.

This PR makes the shorthand utility functions useful when dealing with Hayson types.
Added unit tests to increase the coverage of this module.