### PR TITLE
Add typing for the Dict prop access

### DIFF
--- a/spec/core/HDict.spec.ts
+++ b/spec/core/HDict.spec.ts
@@ -351,6 +351,11 @@ describe('HDict', function (): void {
 				value: HStr.make('foovalue'),
 			})
 		})
+
+		// Required for lodash to work with dict.
+		it('access proxy by property name', function (): void {
+			expect(dict.foo).toEqual(HStr.make('foovalue'))
+		})
 	}) // proxy
 
 	describe('#set()', function (): void {

--- a/src/core/HDict.ts
+++ b/src/core/HDict.ts
@@ -204,6 +204,11 @@ export class HDict implements HVal, Iterable<HValRow> {
 	private readonly $store: DictStore;
 
 	/**
+	 * Readonly key access.
+	 */
+	readonly [prop: string]: unknown | undefined
+
+	/**
 	 * Readonly numerical index access.
 	 */
 	readonly [prop: number]: { name: string; value: OptionalHVal } | undefined


### PR DESCRIPTION
Proposing this feature so one could safely use the proxy access pattern in TypeScript code.