### PR TITLE
Add unit comparison in number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "haystack-core",
-			"version": "2.0.47",
+			"version": "2.0.48",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
 				"@types/jest": "^29.5.2",

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -27,7 +27,7 @@ import {
 } from './units'
 import '../matchers'
 import '../customMatchers'
-import { nanosecond, microsecond } from '../../src/core/duration'
+import { nanosecond, microsecond, year } from '../../src/core/duration'
 
 describe('HNum', function (): void {
 	describe('.make()', function (): void {
@@ -643,6 +643,14 @@ describe('HNum', function (): void {
 				expect(
 					HNum.make(1, nanosecond).compareTo(
 						HNum.make(0.001, microsecond)
+					)
+				).toBe(0)
+			})
+
+			it('one thousand years are equal to a lot of microseconds', function (): void {
+				expect(
+					HNum.make(1000, year).compareTo(
+						HNum.make(31536000000000000, microsecond)
 					)
 				).toBe(0)
 			})

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -623,6 +623,12 @@ describe('HNum', function (): void {
 					HNum.make(1, second).compareTo(HNum.make(1, second))
 				).toBe(0)
 			})
+
+			it('one second is equal to one thousand milliseconds', function (): void {
+				expect(
+					HNum.make(1, second).compareTo(HNum.make(1000, millisecond))
+				).toBe(0)
+			})
 		}) // #compareTo()
 	}) // units
 })

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -639,7 +639,7 @@ describe('HNum', function (): void {
 				).toBe(0)
 			})
 
-			it('one nanoseconds are equal to one thousand microsecond', function (): void {
+			it('one nanosecond is equal to one thousand microseconds', function (): void {
 				expect(
 					HNum.make(1, nanosecond).compareTo(
 						HNum.make(0.001, microsecond)

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -27,6 +27,7 @@ import {
 } from './units'
 import '../matchers'
 import '../customMatchers'
+import { nanosecond, microsecond } from '../../src/core/duration'
 
 describe('HNum', function (): void {
 	describe('.make()', function (): void {
@@ -627,6 +628,22 @@ describe('HNum', function (): void {
 			it('one second is equal to one thousand milliseconds', function (): void {
 				expect(
 					HNum.make(1, second).compareTo(HNum.make(1000, millisecond))
+				).toBe(0)
+			})
+
+			it('one thousand nanoseconds are equal to one microsecond', function (): void {
+				expect(
+					HNum.make(1000, nanosecond).compareTo(
+						HNum.make(1, microsecond)
+					)
+				).toBe(0)
+			})
+
+			it('one nanoseconds are equal to one thousand microsecond', function (): void {
+				expect(
+					HNum.make(1, nanosecond).compareTo(
+						HNum.make(0.001, microsecond)
+					)
 				).toBe(0)
 			})
 		}) // #compareTo()

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -580,5 +580,49 @@ describe('HNum', function (): void {
 				expect(() => HNum.make(1, hour).convertTo(joule)).toThrow()
 			})
 		}) // #convertTo()
+
+		describe('#isDuration()', function (): void {
+			it('returns true for seconds', function (): void {
+				expect(HNum.make(1, second).isDuration()).toBe(true)
+			})
+
+			it('returns true for milliseconds', function (): void {
+				expect(HNum.make(1, millisecond).isDuration()).toBe(true)
+			})
+
+			it('returns false for joule', function (): void {
+				expect(HNum.make(1, joule).isDuration()).toBe(false)
+			})
+
+			it('returns false for celsius', function (): void {
+				expect(HNum.make(1, celsius).isDuration()).toBe(false)
+			})
+		}) // #isDuration()
+
+		describe('#compareTo()', function (): void {
+			it('throws an error when comparing two numbers with incompatible units', function (): void {
+				expect(() =>
+					HNum.make(2, millisecond).compareTo(HNum.make(3, joule))
+				).toThrow('ms <=> J')
+			})
+
+			it('one millisecond is less than one second', function (): void {
+				expect(
+					HNum.make(1, millisecond).compareTo(HNum.make(1, second))
+				).toBe(-1)
+			})
+
+			it('one second is greater than one millisecond', function (): void {
+				expect(
+					HNum.make(1, second).compareTo(HNum.make(1, millisecond))
+				).toBe(1)
+			})
+
+			it('one second is equal to one second', function (): void {
+				expect(
+					HNum.make(1, second).compareTo(HNum.make(1, second))
+				).toBe(0)
+			})
+		}) // #compareTo()
 	}) // units
 })

--- a/spec/core/UnitDatabase.spec.ts
+++ b/spec/core/UnitDatabase.spec.ts
@@ -33,7 +33,7 @@ describe('UnitDatabase', function (): void {
 			})
 
 			db.define(joule2)
-			expect(db.getUnitsForQuantity('energy')).toEqual([joule])
+			expect(db.getUnitsForQuantity('energy')).toEqual([joule2])
 		})
 	}) // #define()
 

--- a/spec/core/UnitDatabase.spec.ts
+++ b/spec/core/UnitDatabase.spec.ts
@@ -4,6 +4,7 @@
 
 import { UnitDatabase } from '../../src/core/UnitDatabase'
 import { joule, pound, square_mile, mile } from './units'
+import { HUnit } from '../../src/core/HUnit'
 
 describe('UnitDatabase', function (): void {
 	let db: UnitDatabase
@@ -19,6 +20,20 @@ describe('UnitDatabase', function (): void {
 	describe('#define()', function (): void {
 		it('does not throw an error if the same unit is defined twice', function (): void {
 			expect(() => db.define(joule)).not.toThrow()
+		})
+
+		it('does not define a unit multiple times in the database', function (): void {
+			// Define joules again but as a different instance.
+			const joule2 = new HUnit({
+				ids: ['joule', 'J'],
+				scale: 1,
+				offset: 0,
+				dimensions: { kg: 1, m: 2, sec: -2, K: 0, A: 0, mol: 0, cd: 0 },
+				quantity: 'energy',
+			})
+
+			db.define(joule2)
+			expect(db.getUnitsForQuantity('energy')).toEqual([joule])
 		})
 	}) // #define()
 

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -18,6 +18,8 @@ import { HDict } from './HDict'
 import { EvalContext } from '../filter/EvalContext'
 import { HUnit } from './HUnit'
 import { JsonV3Num } from './jsonv3'
+import './duration'
+import { millisecond } from './duration'
 
 /**
  * The default numeric precision.
@@ -309,13 +311,35 @@ export class HNum implements HVal {
 			return -1
 		}
 
-		if (this.value < value.value) {
+		let value0 = this.value
+		let value1 = value.value
+
+		if (this.unit && value.unit && !this.unit.equals(value.unit)) {
+			// Allow time comparisons of unlike units.
+			if (this.isDuration() && value.isDuration()) {
+				value0 = this.convertTo(millisecond).value
+				value1 = value.convertTo(millisecond).value
+			} else {
+				throw new Error(`${this.unit.symbol} <=> ${value.unit.symbol}`)
+			}
+		}
+
+		if (value0 < value1) {
 			return -1
 		}
-		if (this.value === value.value) {
+		if (value0 === value1) {
 			return 0
 		}
 		return 1
+	}
+
+	/**
+	 * Returns true if the number is a type of duration.
+	 *
+	 * @returns True if the number is a duration.
+	 */
+	public isDuration(): boolean {
+		return this.unit?.quantity === 'time'
 	}
 
 	/**

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -321,7 +321,7 @@ export class HNum implements HVal {
 				value1 = value.convertTo(millisecond).value
 
 				// Handle floating point comparison.
-				if (Math.abs(value0 - value1) < 0.0000000000001) {
+				if (Math.abs(value0 - value1) < Number.EPSILON) {
 					value0 = value1
 				}
 			} else {

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -321,7 +321,7 @@ export class HNum implements HVal {
 				value1 = value.convertTo(millisecond).value
 
 				// Handle floating point comparison.
-				if (Math.abs(value0 - value1) < 0.0000000001) {
+				if (Math.abs(value0 - value1) < 0.0000000000001) {
 					value0 = value1
 				}
 			} else {

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -319,6 +319,11 @@ export class HNum implements HVal {
 			if (this.isDuration() && value.isDuration()) {
 				value0 = this.convertTo(millisecond).value
 				value1 = value.convertTo(millisecond).value
+
+				// Handle floating point comparison.
+				if (Math.abs(value0 - value1) < 0.0000000001) {
+					value0 = value1
+				}
 			} else {
 				throw new Error(`${this.unit.symbol} <=> ${value.unit.symbol}`)
 			}

--- a/src/core/UnitDatabase.ts
+++ b/src/core/UnitDatabase.ts
@@ -18,7 +18,7 @@ export class UnitDatabase {
 	/**
 	 * All units organized by quantity.
 	 */
-	readonly #quantities = new Map<string, Set<HUnit>>()
+	readonly #quantities = new Map<string, Map<string, HUnit>>()
 
 	/**
 	 * All the registered units.
@@ -38,10 +38,10 @@ export class UnitDatabase {
 			if (quantity) {
 				let units = this.#quantities.get(quantity)
 				if (!units) {
-					units = new Set()
+					units = new Map()
 					this.#quantities.set(quantity, units)
 				}
-				units.add(unit)
+				units.set(unit.name, unit)
 			}
 		}
 

--- a/src/core/UnitDatabase.ts
+++ b/src/core/UnitDatabase.ts
@@ -33,16 +33,16 @@ export class UnitDatabase {
 	public define(unit: HUnit): void {
 		for (const id of unit.ids) {
 			this.#byId.set(id, unit)
+		}
 
-			const quantity = unit.quantity
-			if (quantity) {
-				let units = this.#quantities.get(quantity)
-				if (!units) {
-					units = new Map()
-					this.#quantities.set(quantity, units)
-				}
-				units.set(unit.name, unit)
+		const quantity = unit.quantity
+		if (quantity) {
+			let units = this.#quantities.get(quantity)
+			if (!units) {
+				units = new Map()
+				this.#quantities.set(quantity, units)
 			}
+			units.set(unit.name, unit)
 		}
 
 		this.#units.add(unit)

--- a/src/core/duration.ts
+++ b/src/core/duration.ts
@@ -8,6 +8,10 @@ import { HUnit } from './HUnit'
  * @module
  *
  * Defines all the time units required for number comparison.
+ *
+ * Please note these units were originally created in `haystack-units` whereby
+ * all the units are dynamically created from the Fantom unit database at
+ * build time.
  */
 
 export const nanosecond = HUnit.define({

--- a/src/core/duration.ts
+++ b/src/core/duration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, J2 Innovations. All Rights Reserved
+ * Copyright (c) 2023, J2 Innovations. All Rights Reserved
  */
 
 import { HUnit } from './HUnit'

--- a/src/core/duration.ts
+++ b/src/core/duration.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020, J2 Innovations. All Rights Reserved
+ */
+
+import { HUnit } from './HUnit'
+
+/**
+ * @module
+ *
+ * Defines all the time units required for number comparison.
+ */
+
+export const nanosecond = HUnit.define({
+	ids: ['nanosecond', 'ns'],
+	scale: 1e-9,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const microsecond = HUnit.define({
+	ids: ['microsecond', 'µs'],
+	scale: 0.000001,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const millisecond = HUnit.define({
+	ids: ['millisecond', 'ms'],
+	scale: 0.001,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const hundredthsSecond = HUnit.define({
+	ids: ['hundredths_second', 'cs'],
+	scale: 0.01,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const tenthsSecond = HUnit.define({
+	ids: ['tenths_second', 'ds'],
+	scale: 0.1,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const second = HUnit.define({
+	ids: ['second', 'sec', 's'],
+	scale: 1,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const minute = HUnit.define({
+	ids: ['minute', 'min'],
+	scale: 60,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const hour = HUnit.define({
+	ids: ['hour', 'hr', 'h'],
+	scale: 3600,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const day = HUnit.define({
+	ids: ['day'],
+	scale: 86400,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const week = HUnit.define({
+	ids: ['week', 'wk'],
+	scale: 604800,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const julianMonth = HUnit.define({
+	ids: ['julian_month', 'mo'],
+	scale: 2629800,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})
+
+export const year = HUnit.define({
+	ids: ['year', 'yr'],
+	scale: 31536000,
+	offset: 0,
+	dimensions: { kg: 0, m: 0, sec: 1, K: 0, A: 0, mol: 0, cd: 0 },
+	quantity: 'time',
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export * from './core/UnitDatabase'
 export * from './core/UnitDimensions'
 export * from './core/HSpan'
 export * from './core/jsonv3'
+export * from './core/duration'
 
 // Shorthand
 export * from './shorthand'


### PR DESCRIPTION
I've added some improved number comparison support to HNum.

This matches the Haxall Haystack Number comparison.

I've also made a change to better support duplicate units in the unit database.