### PR TITLE
Add optimizations to primitives

### DIFF
--- a/src/core/HBool.ts
+++ b/src/core/HBool.ts
@@ -44,18 +44,20 @@ export class HBool implements HVal {
 	 * @returns A haystack boolean value.
 	 */
 	public static make(value: boolean | HBool): HBool {
-		if (valueIsKind<HBool>(value, Kind.Bool)) {
-			return value
-		} else if (value) {
-			return (
-				trueInstance ||
-				(trueInstance = Object.freeze(new HBool(true)) as HBool)
-			)
+		if (typeof value === 'boolean') {
+			if (value) {
+				return (
+					trueInstance ||
+					(trueInstance = Object.freeze(new HBool(true)) as HBool)
+				)
+			} else {
+				return (
+					falseInstance ||
+					(falseInstance = Object.freeze(new HBool(false)) as HBool)
+				)
+			}
 		} else {
-			return (
-				falseInstance ||
-				(falseInstance = Object.freeze(new HBool(false)) as HBool)
-			)
+			return value
 		}
 	}
 

--- a/src/core/HBool.ts
+++ b/src/core/HBool.ts
@@ -47,13 +47,13 @@ export class HBool implements HVal {
 		if (typeof value === 'boolean') {
 			if (value) {
 				return (
-					trueInstance ||
-					(trueInstance = Object.freeze(new HBool(true)) as HBool)
+					trueInstance ??
+					Object.freeze((trueInstance = new HBool(true)))
 				)
 			} else {
 				return (
-					falseInstance ||
-					(falseInstance = Object.freeze(new HBool(false)) as HBool)
+					falseInstance ??
+					Object.freeze((falseInstance = new HBool(false)))
 				)
 			}
 		} else {

--- a/src/core/HCoord.ts
+++ b/src/core/HCoord.ts
@@ -85,9 +85,7 @@ export class HCoord implements HVal {
 		if (valueIsKind<HCoord>(value, Kind.Coord)) {
 			return value
 		} else {
-			return Object.freeze(
-				new HCoord(value as CoordObj | HaysonCoord)
-			) as HCoord
+			return new HCoord(value as CoordObj | HaysonCoord)
 		}
 	}
 

--- a/src/core/HDate.ts
+++ b/src/core/HDate.ts
@@ -102,9 +102,7 @@ export class HDate implements HVal {
 		if (valueIsKind<HDate>(value, Kind.Date)) {
 			return value
 		} else {
-			return Object.freeze(
-				new HDate(value as string | Date | DateObj | HaysonDate)
-			) as HDate
+			return new HDate(value as string | Date | DateObj | HaysonDate)
 		}
 	}
 

--- a/src/core/HDateTime.ts
+++ b/src/core/HDateTime.ts
@@ -176,9 +176,7 @@ export class HDateTime implements HVal {
 		if (valueIsKind<HDateTime>(value, Kind.DateTime)) {
 			return value
 		} else {
-			return Object.freeze(
-				new HDateTime(value as string | Date | HaysonDateTime)
-			) as HDateTime
+			return new HDateTime(value as string | Date | HaysonDateTime)
 		}
 	}
 

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -114,11 +114,8 @@ export class HNum implements HVal {
 		}
 
 		return val === 0 && !unit
-			? zeroNoUnitsNum ||
-					(zeroNoUnitsNum = Object.freeze(
-						new HNum(val, unit)
-					) as HNum)
-			: (Object.freeze(new HNum(val, unit)) as HNum)
+			? zeroNoUnitsNum || (zeroNoUnitsNum = new HNum(val, unit))
+			: new HNum(val, unit)
 	}
 
 	/**

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -312,7 +312,8 @@ export class HNum implements HVal {
 		let value0 = this.value
 		let value1 = value.value
 
-		if (this.unit && value.unit && !this.unit.equals(value.unit)) {
+		const unit = this.unit
+		if (unit && value.unit && !unit.equals(value.unit)) {
 			// Allow time comparisons of unlike units.
 			if (this.isDuration() && value.isDuration()) {
 				value0 = this.convertTo(millisecond).value
@@ -323,7 +324,7 @@ export class HNum implements HVal {
 					value0 = value1
 				}
 			} else {
-				throw new Error(`${this.unit.symbol} <=> ${value.unit.symbol}`)
+				throw new Error(`${unit.symbol} <=> ${value.unit.symbol}`)
 			}
 		}
 

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -114,7 +114,8 @@ export class HNum implements HVal {
 		}
 
 		return val === 0 && !unit
-			? zeroNoUnitsNum || (zeroNoUnitsNum = new HNum(val, unit))
+			? zeroNoUnitsNum ??
+					Object.freeze((zeroNoUnitsNum = new HNum(val, unit)))
 			: new HNum(val, unit)
 	}
 

--- a/src/core/HRef.ts
+++ b/src/core/HRef.ts
@@ -74,9 +74,7 @@ export class HRef implements HVal {
 		if (valueIsKind<HRef>(value, Kind.Ref)) {
 			return value
 		} else {
-			return Object.freeze(
-				new HRef(value as string | HaysonRef, displayName)
-			) as HRef
+			return new HRef(value as string | HaysonRef, displayName)
 		}
 	}
 

--- a/src/core/HStr.ts
+++ b/src/core/HStr.ts
@@ -43,15 +43,12 @@ export class HStr implements HVal {
 	 * @returns A haystack string.
 	 */
 	public static make(value: string | HStr): HStr {
-		if (valueIsKind<HStr>(value, Kind.Str)) {
+		if (typeof value === 'string') {
 			return value
+				? new HStr(value)
+				: emptyStr || (emptyStr = new HStr(value))
 		} else {
-			const valStr = String(value)
-
-			return valStr
-				? (Object.freeze(new HStr(valStr)) as HStr)
-				: emptyStr ||
-						(emptyStr = Object.freeze(new HStr(valStr)) as HStr)
+			return value
 		}
 	}
 

--- a/src/core/HStr.ts
+++ b/src/core/HStr.ts
@@ -46,7 +46,7 @@ export class HStr implements HVal {
 		if (typeof value === 'string') {
 			return value
 				? new HStr(value)
-				: emptyStr || (emptyStr = new HStr(value))
+				: emptyStr ?? Object.freeze((emptyStr = new HStr(value)))
 		} else {
 			return value
 		}

--- a/src/core/HSymbol.ts
+++ b/src/core/HSymbol.ts
@@ -16,7 +16,6 @@ import { HGrid } from './HGrid'
 import { HList } from './HList'
 import { HDict } from './HDict'
 import { EvalContext } from '../filter/EvalContext'
-import { memoize } from '../util/memoize'
 import { JsonV3Symbol } from './jsonv3'
 
 export interface PartialHaysonSymbol {
@@ -64,19 +63,8 @@ export class HSymbol implements HVal {
 				valStr = obj.val
 			}
 
-			return HSymbol.makeInterned(valStr)
+			return new HSymbol(valStr)
 		}
-	}
-
-	/**
-	 * Returns an interned symbol value.
-	 *
-	 * @param value The value to make.
-	 * @returns An interned symbol value.
-	 */
-	@memoize()
-	private static makeInterned(value: string): HSymbol {
-		return Object.freeze(new HSymbol(value)) as HSymbol
 	}
 
 	/**

--- a/src/core/HTime.ts
+++ b/src/core/HTime.ts
@@ -97,9 +97,7 @@ export class HTime implements HVal {
 		if (valueIsKind<HTime>(value, Kind.Time)) {
 			return value
 		} else {
-			return Object.freeze(
-				new HTime(value as string | Date | TimeObj | HaysonTime)
-			) as HTime
+			return new HTime(value as string | Date | TimeObj | HaysonTime)
 		}
 	}
 

--- a/src/core/HUri.ts
+++ b/src/core/HUri.ts
@@ -74,7 +74,7 @@ export class HUri implements HVal {
 				val = obj.val
 			}
 
-			return Object.freeze(new HUri(val)) as HUri
+			return new HUri(val)
 		}
 	}
 

--- a/src/core/HXStr.ts
+++ b/src/core/HXStr.ts
@@ -65,9 +65,7 @@ export class HXStr implements HVal {
 		if (valueIsKind<HXStr>(type, Kind.XStr)) {
 			return type
 		} else {
-			return Object.freeze(
-				new HXStr(type as string | HaysonXStr, value)
-			) as HXStr
+			return new HXStr(type as string | HaysonXStr, value)
 		}
 	}
 


### PR DESCRIPTION
After some performance testing using V8, I found some minor tweaks I could make to Haystack Core that will make a difference to its performance. I'm sure there are more. However these changes are based on real tests and seem to have an impact in my tests...

- Stop using Object.freeze for primitive values that are not interned.
- Prefer typeof over valueIsKind where possible.
- Stop using interning for HSymbol using memoize. It adds an necessary overhead.