### PR TITLE
Include lib name in def resolution error.

### DIFF
--- a/src/core/HNormalizer.ts
+++ b/src/core/HNormalizer.ts
@@ -522,6 +522,7 @@ export class HNormalizer {
 
 		if (!tagLib) {
 			throw this.fatal('couldNotFindLibForDef', {
+				libName: defLib.name,
 				defName: tag,
 			})
 		}


### PR DESCRIPTION
When a pod has a def error, the name of that pod was not included in the error. This should fix that.