### PR TITLE
Add EnumTag support

### DIFF
--- a/spec/core/EnumTag.spec.ts
+++ b/spec/core/EnumTag.spec.ts
@@ -72,6 +72,26 @@ describe('EnumTag', () => {
 				c: 3,
 			})
 		})
+
+		it('creates an enum tag from a grid with no codes', () => {
+			const grid = new HGrid([
+				new HDict({
+					name: 'a',
+				}),
+				new HDict({
+					name: 'b',
+				}),
+				new HDict({
+					name: 'c',
+				}),
+			])
+
+			expect(new EnumTag(grid).encodeToObject()).toEqual({
+				a: 0,
+				b: 1,
+				c: 2,
+			})
+		})
 	}) // construction
 
 	describe('#nameToCode()', () => {

--- a/spec/core/EnumTag.spec.ts
+++ b/spec/core/EnumTag.spec.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2024, J2 Innovations. All Rights Reserved
+ */
+
+import { HStr } from '../../src/core/HStr'
+import { HGrid } from '../../src/core/HGrid'
+import { HDict } from '../../src/core/HDict'
+import { HNum } from '../../src/core/HNum'
+import { HBool } from '../../src/core/HBool'
+import { EnumTag } from '../../src/core/EnumTag'
+import { makeValue } from '../../src/core/util'
+
+describe('EnumTag', () => {
+	describe('construction', () => {
+		it('creates an enum tag from a string', () => {
+			expect(new EnumTag('a,b,c').encodeToObject()).toEqual({
+				a: 0,
+				b: 1,
+				c: 2,
+			})
+		})
+
+		it('creates an enum tag from a haystack string', () => {
+			expect(new EnumTag(HStr.make('a,b,c')).encodeToObject()).toEqual({
+				a: 0,
+				b: 1,
+				c: 2,
+			})
+		})
+
+		it('creates an enum tag from a string with different indexes', () => {
+			expect(new EnumTag('a,,,b,,c,,,').encodeToObject()).toEqual({
+				a: 0,
+				b: 3,
+				c: 5,
+			})
+		})
+
+		it('creates an enum tag from an object', () => {
+			const obj = {
+				a: 0,
+				b: 1,
+				c: 2,
+			}
+
+			expect(new EnumTag(obj).encodeToObject()).toEqual({
+				a: 0,
+				b: 1,
+				c: 2,
+			})
+		})
+
+		it('creates an enum tag from a grid', () => {
+			const grid = new HGrid([
+				new HDict({
+					name: 'a',
+					code: 1,
+				}),
+				new HDict({
+					name: 'b',
+					code: 2,
+				}),
+				new HDict({
+					name: 'c',
+					code: 3,
+				}),
+			])
+
+			expect(new EnumTag(grid).encodeToObject()).toEqual({
+				a: 1,
+				b: 2,
+				c: 3,
+			})
+		})
+	}) // construction
+
+	describe('#nameToCode()', () => {
+		it('returns a code for a name for a', () => {
+			expect(new EnumTag('a,b,c').nameToCode('a')).toBe(0)
+		})
+
+		it('returns a haystack string code for a name for a', () => {
+			expect(new EnumTag('a,b,c').nameToCode(HStr.make('a'))).toBe(0)
+		})
+
+		it('returns a code for a name for b', () => {
+			expect(new EnumTag('a,b,c').nameToCode('b')).toBe(1)
+		})
+
+		it('returns undefined when a name cannot be found', () => {
+			expect(new EnumTag('a,b,c').nameToCode('notFound')).toBe(undefined)
+		})
+	}) // #nameToCode()
+
+	describe('#codeToName()', () => {
+		it('returns a name from a code for 0', () => {
+			expect(new EnumTag('a,b,c').codeToName(0)).toBe('a')
+		})
+
+		it('returns a name from a code for a haystack number 0', () => {
+			expect(new EnumTag('a,b,c').codeToName(HNum.make(0))).toBe('a')
+		})
+
+		it('returns a name from a code for 1', () => {
+			expect(new EnumTag('a,b,c').codeToName(1)).toBe('b')
+		})
+
+		it('returns undefined for a code that cannot be found', () => {
+			expect(new EnumTag('a,b,c').codeToName(99)).toBe(undefined)
+		})
+	}) // #codeToName()
+
+	describe('#nameToBool()', () => {
+		it('returns false for a', () => {
+			expect(new EnumTag('a,b,c').nameToBool('a')).toBe(false)
+		})
+
+		it('returns false for haystack string a', () => {
+			expect(new EnumTag('a,b,c').nameToBool(HStr.make('a'))).toBe(false)
+		})
+
+		it('returns true for b', () => {
+			expect(new EnumTag('a,b,c').nameToBool('b')).toBe(true)
+		})
+
+		it('returns true for c', () => {
+			expect(new EnumTag('a,b,c').nameToBool('c')).toBe(true)
+		})
+
+		it('returns undefined for notFound for c', () => {
+			expect(new EnumTag('a,b,c').nameToBool('notFound')).toBe(undefined)
+		})
+	}) // #nameToBool()
+
+	describe('#boolToName()', () => {
+		it('returns a for false', () => {
+			expect(new EnumTag('a,b,c').boolToName(false)).toBe('a')
+		})
+
+		it('returns b for true', () => {
+			expect(new EnumTag('a,b,c').boolToName(true)).toBe('b')
+		})
+
+		it('returns b for haystack boolean true', () => {
+			expect(new EnumTag('a,b,c').boolToName(HBool.make(true))).toBe('b')
+		})
+	}) // #boolToName()
+
+	describe('#size', () => {
+		it('returns the number of enumerations', () => {
+			expect(new EnumTag('a,b,c').size).toBe(3)
+		})
+	}) // #size
+
+	describe('#names', () => {
+		it('returns the names', () => {
+			expect(new EnumTag('a,b,c').names).toEqual(['a', 'b', 'c'])
+		})
+	}) // #names
+
+	describe('#encodeToString()', () => {
+		it('encodes enumerations to a string', () => {
+			expect(new EnumTag('a,b,c').encodeToString()).toBe('a,b,c')
+		})
+
+		it('encodes enumerations with different indexes to a string', () => {
+			expect(new EnumTag(',,a,,,,,b,,,c,,,,,').encodeToString()).toBe(
+				',,a,,,,,b,,,c'
+			)
+		})
+	}) // #encodeToString()
+
+	describe('#encodeToGrid()', () => {
+		it('encodes enumerations to a grid', () => {
+			expect(new EnumTag('a,b,c').encodeToGrid().toJSON()).toEqual(
+				new HGrid([
+					new HDict({
+						name: 'a',
+						code: 0,
+					}),
+					new HDict({
+						name: 'b',
+						code: 1,
+					}),
+					new HDict({
+						name: 'c',
+						code: 2,
+					}),
+				]).toJSON()
+			)
+		})
+	}) // #encodeToGrid()
+
+	describe('#encodeToObject()', () => {
+		it('encode the enumerations to an object', () => {
+			expect(new EnumTag('a,b,c').encodeToObject()).toEqual({
+				a: 0,
+				b: 1,
+				c: 2,
+			})
+		})
+	}) // #encodeToObject()
+
+	describe('.encodeToEnumMetaDict()', () => {
+		it('encodes to a dict', () => {
+			const obj = {
+				alpha: new EnumTag('a,b,c'),
+				beta: new EnumTag('d,e,f'),
+				gamma: new EnumTag('g,h,i'),
+			}
+
+			expect(EnumTag.encodeToEnumMetaDict(obj).toJSON()).toEqual({
+				alpha: 'ver:"3.0"\nname,code\n"a",0\n"b",1\n"c",2\n',
+				beta: 'ver:"3.0"\nname,code\n"d",0\n"e",1\n"f",2\n',
+				gamma: 'ver:"3.0"\nname,code\n"g",0\n"h",1\n"i",2\n',
+			})
+		})
+	}) // .encodeToEnumMetaDict()
+
+	describe('.decodeFromEnumMetaDict()', () => {
+		it('decodes from a dict', () => {
+			const dict = makeValue({
+				alpha: 'ver:"3.0"\nname,code\n"a",0\n"b",1\n"c",2\n',
+				beta: 'ver:"3.0"\nname,code\n"d",0\n"e",1\n"f",2\n',
+				gamma: 'ver:"3.0"\nname,code\n"g",0\n"h",1\n"i",2\n',
+			}) as HDict
+
+			expect(EnumTag.decodeFromEnumMetaDict(dict)).toEqual({
+				alpha: new EnumTag('a,b,c'),
+				beta: new EnumTag('d,e,f'),
+				gamma: new EnumTag('g,h,i'),
+			})
+		})
+	}) // .decodeFromEnumMetaDict()
+})

--- a/src/core/EnumTag.ts
+++ b/src/core/EnumTag.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2024, J2 Innovations. All Rights Reserved
+ */
+
+import { HBool } from './HBool'
+import { HDict } from './HDict'
+import { HGrid } from './HGrid'
+import { HNum } from './HNum'
+import { HStr } from './HStr'
+import { valueIsKind } from './HVal'
+import { Kind } from './Kind'
+import { ZincReader } from './ZincReader'
+
+function toGrid(value: unknown): HGrid | undefined {
+	if (valueIsKind<HGrid>(value, Kind.Grid)) {
+		return value
+	}
+
+	try {
+		const hval = ZincReader.readValue(String(value))
+		return valueIsKind<HGrid>(hval, Kind.Grid) ? hval : undefined
+	} catch {
+		return undefined
+	}
+}
+
+function toString(value: string | HStr): string {
+	return String(value)
+}
+
+function toBool(value: boolean | HBool): boolean {
+	return typeof value === 'boolean' ? value : value.value
+}
+
+function toNum(value: number | HNum): number {
+	return typeof value === 'number' ? value : value.value
+}
+
+/**
+ * Enumerated tag support.
+ *
+ * Handles `enumMeta` code mappings.
+ *
+ * Enumerations in haystack don't have a first class mapping. There is no `enum` kind. Instead an enumerated
+ * point its kind tag set to `Str` with an additional `enum` tag that defines the enumerations to use.
+ * The string is comma separated and each enum should be a valid tag name.
+ *
+ * The `enumMeta` record is a record that should be considered a singleton. This is used to reference
+ * enumerations that could be used on points and other parts of the system.
+ */
+export class EnumTag {
+	readonly trueName?: string
+	readonly falseName?: string
+
+	readonly #nameToCodeMap = new Map<string, number>()
+	readonly #codeToNameMap = new Map<number, string>()
+
+	/**
+	 * Constructs a new enum tag.
+	 *
+	 * @param data A comma separated string of enumerations, enum grid or enum name to code object.
+	 */
+	constructor(data: string | HStr | HGrid | Record<string, number>) {
+		let trueName: string | undefined
+		let falseName: string | undefined
+
+		const addEnumEntry = (name: string, code: number): void => {
+			if (!trueName && code) {
+				trueName = name
+			}
+			if (!falseName && !code) {
+				falseName = name
+			}
+			if (!this.#nameToCodeMap.has(name)) {
+				this.#nameToCodeMap.set(name, code)
+			}
+			if (!this.#codeToNameMap.has(code)) {
+				this.#codeToNameMap.set(code, name)
+			}
+		}
+
+		if (typeof data === 'string' || valueIsKind<HStr>(data, Kind.Str)) {
+			String(data)
+				.split(',')
+				.forEach((name, code) => {
+					if (name) {
+						addEnumEntry(name, code)
+					}
+				})
+		} else if (valueIsKind<HGrid>(data, Kind.Grid)) {
+			data.getRows().forEach((row, i) => {
+				const name = row.get<HStr>('name')?.value
+
+				if (name) {
+					addEnumEntry(name, row.get<HNum>('code')?.value ?? i)
+				}
+			})
+		} else {
+			Object.keys(data).forEach((name) => {
+				const code = data[name]
+
+				if (typeof name === 'string' && typeof code === 'number') {
+					addEnumEntry(name, code)
+				}
+			})
+		}
+
+		this.trueName = trueName
+		this.falseName = falseName
+	}
+
+	/**
+	 * Convert a name to a code.
+	 *
+	 * @param name The enumeration name.
+	 * @returns The code for the enumeration or undefined if not found.
+	 */
+	nameToCode(name: string | HStr): number | undefined {
+		return this.#nameToCodeMap.get(toString(name))
+	}
+
+	/**
+	 * Convert a code to a name.
+	 *
+	 * @param code The enumeration code.
+	 * @returns The enumeration name or undefined if not found.
+	 */
+	codeToName(code: number | HNum): string | undefined {
+		return this.#codeToNameMap.get(toNum(code))
+	}
+
+	/**
+	 * Convert a name to a boolean value.
+	 *
+	 * @param name The name to convert.
+	 * @returns The boolean value or undefined if not found.
+	 */
+	nameToBool(name: string | HStr): boolean | undefined {
+		const code = this.#nameToCodeMap.get(toString(name))
+		return code === undefined ? undefined : !!code
+	}
+
+	/**
+	 * Converts a boolean value to a name.
+	 *
+	 * @param value The boolean value to convert.
+	 * @returns The name or undefined if not found.
+	 */
+	boolToName(value: boolean | HBool): string | undefined {
+		return toBool(value) ? this.trueName : this.falseName
+	}
+
+	/**
+	 * @returns The number of enumerated entries.
+	 */
+	get size(): number {
+		return this.#nameToCodeMap.size
+	}
+
+	/**
+	 * @returns The enumerated names.
+	 */
+	get names(): string[] {
+		return [...this.#nameToCodeMap.keys()]
+	}
+
+	/**
+	 * @returns encode the enumerations to a string.
+	 */
+	encodeToString(): string {
+		const values: string[] = []
+
+		for (const [name, code] of this.#nameToCodeMap) {
+			values[code] = name
+		}
+
+		return values.map((v) => v ?? '').join(',')
+	}
+
+	/**
+	 * @returns encode the enumerations to a grid.
+	 */
+	encodeToGrid(): HGrid {
+		const rows: HDict[] = []
+
+		for (const name of this.#nameToCodeMap.keys()) {
+			const code = this.nameToCode(name)
+
+			if (code !== undefined) {
+				rows.push(
+					new HDict({
+						name,
+						code,
+					})
+				)
+			}
+		}
+
+		return new HGrid(rows)
+	}
+
+	/**
+	 * @returns encodes the enumerations to an object.
+	 */
+	encodeToObject(): Record<string, number> {
+		const obj: Record<string, number> = {}
+
+		for (const name of this.#nameToCodeMap.keys()) {
+			const code = this.nameToCode(name)
+
+			if (code !== undefined) {
+				obj[name] = code
+			}
+		}
+
+		return obj
+	}
+
+	/**
+	 * Encodes the enum tags into an enum meta dict.
+	 *
+	 * @param enumTags The enum tags to encode.
+	 * @returns The encoded enum meta record.
+	 */
+	static encodeToEnumMetaDict(enumTags: Record<string, EnumTag>): HDict {
+		const enumMeta = new HDict()
+
+		for (const name of Object.keys(enumTags)) {
+			const enumTag = enumTags[name]
+
+			if (enumTag) {
+				const grid = enumTag.encodeToGrid()
+
+				if (!grid.isEmpty()) {
+					enumMeta.set(name, grid.toZinc())
+				}
+			}
+		}
+
+		return enumMeta
+	}
+
+	/**
+	 * Decodes the enum meta record into some enum tags.
+	 *
+	 * @param dict The `enumMeta` dict to decode.
+	 * @returns The decoded enum tag information.
+	 */
+	static decodeFromEnumMetaDict(dict: HDict): Record<string, EnumTag> {
+		const enumTags: Record<string, EnumTag> = {}
+
+		for (const { name, value } of dict) {
+			const grid = toGrid(value)
+
+			if (grid) {
+				enumTags[name] = new EnumTag(grid)
+			}
+		}
+
+		return enumTags
+	}
+}

--- a/src/core/EnumTag.ts
+++ b/src/core/EnumTag.ts
@@ -65,16 +65,17 @@ export class EnumTag {
 		let falseName: string | undefined
 
 		const addEnumEntry = (name: string, code: number): void => {
-			if (!trueName && code) {
-				trueName = name
-			}
-			if (!falseName && !code) {
-				falseName = name
-			}
-			if (!this.#nameToCodeMap.has(name)) {
+			if (
+				!this.#nameToCodeMap.has(name) &&
+				!this.#codeToNameMap.has(code)
+			) {
+				if (!trueName && code) {
+					trueName = name
+				}
+				if (!falseName && !code) {
+					falseName = name
+				}
 				this.#nameToCodeMap.set(name, code)
-			}
-			if (!this.#codeToNameMap.has(code)) {
 				this.#codeToNameMap.set(code, name)
 			}
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export * from './core/UnitDatabase'
 export * from './core/UnitDimensions'
 export * from './core/HSpan'
 export * from './core/jsonv3'
+export * from './core/EnumTag'
 
 // Shorthand
 export * from './shorthand'


### PR DESCRIPTION
Adds support for parsing an encoding enums. Includes support for handling `enumMeta`.

Encoding and decoding for enum `defs` will be handled separately.