### PR TITLE
Use UTC for HDate, fix HTime and HDateTime.toAxon

### DIFF
--- a/spec/core/HDateTime.spec.ts
+++ b/spec/core/HDateTime.spec.ts
@@ -216,8 +216,26 @@ describe('HDateTime', function (): void {
 	describe('#toAxon()', function (): void {
 		it('returns an Axon string', function (): void {
 			expect(HDateTime.make('2009-11-09T15:39:00Z').toAxon()).toBe(
-				'dateTime(2009-11-09,15:39:00)'
+				'dateTime(2009-11-09,15:39:00,"UTC")'
 			)
+		})
+
+		it('returns an Axon string with the timezone set to UTC', function (): void {
+			expect(
+				HDateTime.make({
+					_kind: Kind.DateTime,
+					val: '2009-11-09T15:39:00Z',
+					tz: 'London',
+				}).toAxon()
+			).toBe('dateTime(2009-11-09,15:39:00,"UTC")')
+		})
+
+		it('returns an Axon string with an offset and the timezone set to UTC', function () {
+			expect(
+				HDateTime.make(
+					'2021-04-14T07:42:46.275-05:00 New_York'
+				).toAxon()
+			).toBe('dateTime(2021-04-14,12:42:46.275,"UTC")')
 		})
 	}) // #toAxon()
 

--- a/src/core/HDate.ts
+++ b/src/core/HDate.ts
@@ -305,14 +305,9 @@ export class HDate implements HVal {
 	 * @throws An error if the date can't be found.
 	 */
 	private static getDateFromDateObj(date: Date): string {
-		return `${date.getUTCFullYear()}-${HDate.encodeDigits(
+		return `${date.getUTCFullYear()}-${String(
 			date.getUTCMonth() + 1
-		)}-${this.encodeDigits(date.getUTCDate())}`
-	}
-
-	private static encodeDigits(value: number): string {
-		const val = String(value)
-		return val.length === 1 ? `0${val}` : val
+		).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`
 	}
 
 	/**

--- a/src/core/HDate.ts
+++ b/src/core/HDate.ts
@@ -305,15 +305,14 @@ export class HDate implements HVal {
 	 * @throws An error if the date can't be found.
 	 */
 	private static getDateFromDateObj(date: Date): string {
-		// Parse date string from ISO format.
-		const iso = date.toISOString() || ''
-		const res = /^([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])./.exec(iso)
+		return `${date.getUTCFullYear()}-${HDate.encodeDigits(
+			date.getUTCMonth() + 1
+		)}-${this.encodeDigits(date.getUTCDate())}`
+	}
 
-		if (!res || !res[1]) {
-			throw new Error('Invalid date')
-		}
-
-		return res[1]
+	private static encodeDigits(value: number): string {
+		const val = String(value)
+		return val.length === 1 ? `0${val}` : val
 	}
 
 	/**

--- a/src/core/HDateTime.ts
+++ b/src/core/HDateTime.ts
@@ -375,9 +375,10 @@ export class HDateTime implements HVal {
 	 */
 	public toAxon(): string {
 		const date = this.date
+
 		return `dateTime(${HDate.make(date).toAxon()},${HTime.make(
 			date
-		).toAxon()})`
+		).toAxon()},"UTC")`
 	}
 
 	/**

--- a/src/core/HTime.ts
+++ b/src/core/HTime.ts
@@ -287,7 +287,7 @@ export class HTime implements HVal {
 		const hours = date.getUTCHours()
 		const minutes = date.getUTCMinutes()
 		const seconds = date.getUTCSeconds()
-		const ms = date.getMilliseconds()
+		const ms = date.getUTCMilliseconds()
 
 		return HTime.getTime(hours, minutes, seconds, ms)
 	}


### PR DESCRIPTION
We found a few issues with `HDateTime.toAxon()` that lead onto a wider discussion using UTC time for constructing `HDate` and `HTime`.

- `HDateTime.toAxon()`: this now always creates a `dateTime(...)` calling using the correct UTC format.
- `HDate` now uses UTC when constructed from a Date. 
- `HTime` now uses UTC for milliseconds. This was missing.