### PR TITLE
Add option to shorten a display name

### DIFF
--- a/spec/core/HDict.spec.ts
+++ b/spec/core/HDict.spec.ts
@@ -15,6 +15,7 @@ import { HGrid } from '../../src/core/HGrid'
 import { HVal } from '../../src/core/HVal'
 import { HSymbol } from '../../src/core/HSymbol'
 import { HNamespace } from '../../src/core/HNamespace'
+import { HRef } from '../../src/core/HRef'
 import { HaysonDict } from '../../src/core/hayson'
 import { HFilter } from '../../src/filter/HFilter'
 import '../matchers'
@@ -813,6 +814,17 @@ describe('HDict', function (): void {
 				'test'
 			)
 			expect(i18n).toHaveBeenCalledWith('pod', 'key')
+		})
+
+		it('returns a shortened display name from a macro', function (): void {
+			const dict = new HDict({
+				navName: HStr.make('a nav name'),
+				equipRef: HRef.make('equipRef'),
+				siteRef: HRef.make('siteRef'),
+				disMacro: HStr.make('    $siteRef $equipRef $navName   '),
+			})
+
+			expect(dict.toDis({ short: true })).toBe('a nav name')
 		})
 	}) // #toDis()
 

--- a/spec/core/Util.spec.ts
+++ b/spec/core/Util.spec.ts
@@ -646,6 +646,10 @@ describe('util', function (): void {
 			)
 		})
 
+		it('returns navName', function (): void {
+			expect(dictToDis(new HDict({ dis: 'navName' }))).toBe('navName')
+		})
+
 		it('returns shortened display name with starting refs skipped', function (): void {
 			const dict = new HDict({
 				navName: HStr.make('a nav name'),
@@ -659,19 +663,6 @@ describe('util', function (): void {
 			expect(
 				dictToDis(dict, undefined, undefined, /*shorten*/ true)
 			).toBe('a nav name')
-		})
-
-		it('returns display name when shortened but initial pass is empty', function (): void {
-			const dict = new HDict({
-				navName: HStr.make('a nav name'),
-				equipRef: HRef.make('equipRef'),
-				siteRef: HRef.make('siteRef'),
-				disMacro: HStr.make('    $siteRef $equipRef   '),
-			})
-
-			expect(
-				dictToDis(dict, undefined, undefined, /*shorten*/ true)
-			).toBe('siteRef equipRef')
 		})
 	}) // dictToDis()
 

--- a/spec/core/Util.spec.ts
+++ b/spec/core/Util.spec.ts
@@ -645,6 +645,34 @@ describe('util', function (): void {
 				'dis'
 			)
 		})
+
+		it('returns shortened display name with starting refs skipped', function (): void {
+			const dict = new HDict({
+				navName: HStr.make('a nav name'),
+				equipRef: HRef.make('equipRef'),
+				siteRef: HRef.make('siteRef'),
+				disMacro: HStr.make('    $siteRef $equipRef $navName   '),
+			})
+
+			// Shortening a display name will remove any refs from output of
+			// processing `disMacro`.
+			expect(
+				dictToDis(dict, undefined, undefined, /*shorten*/ true)
+			).toBe('a nav name')
+		})
+
+		it('returns display name when shortened but initial pass is empty', function (): void {
+			const dict = new HDict({
+				navName: HStr.make('a nav name'),
+				equipRef: HRef.make('equipRef'),
+				siteRef: HRef.make('siteRef'),
+				disMacro: HStr.make('    $siteRef $equipRef   '),
+			})
+
+			expect(
+				dictToDis(dict, undefined, undefined, /*shorten*/ true)
+			).toBe('siteRef equipRef')
+		})
 	}) // dictToDis()
 
 	describe('macro()', function (): void {
@@ -716,6 +744,13 @@ describe('util', function (): void {
 			expect(macro('$ref$ref $ref something', makeGetValue(scope))).toBe(
 				'IdId Id something'
 			)
+		})
+
+		it('trims any whitespace', function (): void {
+			const scope = new HDict({ ref: HRef.make('id', 'Id') })
+			expect(
+				macro('   $ref$ref $ref something    ', makeGetValue(scope))
+			).toBe('IdId Id something')
 		})
 	}) // macro()
 

--- a/spec/core/Util.spec.ts
+++ b/spec/core/Util.spec.ts
@@ -647,7 +647,7 @@ describe('util', function (): void {
 		})
 
 		it('returns navName', function (): void {
-			expect(dictToDis(new HDict({ dis: 'navName' }))).toBe('navName')
+			expect(dictToDis(new HDict({ navName: 'navName' }))).toBe('navName')
 		})
 
 		it('returns shortened display name with starting refs skipped', function (): void {
@@ -658,8 +658,6 @@ describe('util', function (): void {
 				disMacro: HStr.make('    $siteRef $equipRef $navName   '),
 			})
 
-			// Shortening a display name will remove any refs from output of
-			// processing `disMacro`.
 			expect(
 				dictToDis(dict, undefined, undefined, /*shorten*/ true)
 			).toBe('a nav name')

--- a/src/core/HDict.ts
+++ b/src/core/HDict.ts
@@ -840,9 +840,7 @@ export class HDict implements HVal, Iterable<HValRow> {
 	 * @param options.name Optional tag name.
 	 * @param options.def Optional default value.
 	 * @param options.i18n Optional function to get localized strings.
-	 * @param options.short Optional flag to automatically shorten the display
-	 * name when processing a `disMacro` tag. This will automatically remove any
-	 * resolved `Ref` values from the macro.
+	 * @param options.short Optional flag to automatically shorten the display name.
 	 * @returns The display string.
 	 */
 	public toDis({

--- a/src/core/HDict.ts
+++ b/src/core/HDict.ts
@@ -840,20 +840,25 @@ export class HDict implements HVal, Iterable<HValRow> {
 	 * @param options.name Optional tag name.
 	 * @param options.def Optional default value.
 	 * @param options.i18n Optional function to get localized strings.
-	 * @returns The display string
+	 * @param options.short Optional flag to automatically shorten the display
+	 * name when processing a `disMacro` tag. This will automatically remove any
+	 * resolved `Ref` values from the macro.
+	 * @returns The display string.
 	 */
 	public toDis({
 		name,
 		def,
 		i18n,
+		short,
 	}: {
 		name?: string
 		def?: string
 		i18n?: LocalizedCallback
+		short?: boolean
 	} = {}): string {
 		return name
 			? this.get(name)?.toString() ?? def ?? ''
-			: dictToDis(this, def, i18n)
+			: dictToDis(this, def, i18n, short)
 	}
 
 	/**

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -376,8 +376,8 @@ export interface LocalizedCallback {
  * 4. 'name' tag.
  * 5. 'tag' tag.
  * 6. 'navName' tag.
- * 6. 'id' tag.
- * 7. default
+ * 7. 'id' tag.
+ * 8. default
  *
  * If a short name is specified, resolving `disMacro` is given a
  * lower precedence.

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -368,7 +368,7 @@ export interface LocalizedCallback {
 }
 
 /**
- * Return a display string from the dict (or function)...
+ * Return a display string from the dict...
  *
  * 1. 'dis' tag.
  * 2. 'disMacro' tag returns macro using dict as scope.

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -379,7 +379,7 @@ export interface LocalizedCallback {
  * 6. 'id' tag.
  * 7. default
  *
- * If a short name is specified, resolving `disMacro` is given
+ * If a short name is specified, resolving `disMacro` is given a
  * lower precedence.
  *
  * @see {@link HDict.toDis}


### PR DESCRIPTION
We need some support for shortened display names.

This differs from the relative display names that exist in Haxall. In our use case, we may not have the parent when we have a shortened display name.

So how to handle it? Firstly we need to understand that display names can be processed in different ways (`dis`, `disMacro`, `name` etc). A long display name normally incorporates refs to other records. This uses `disMacro`. For example, if there was a `disMacro` tag on a point with `$equipRef $navName`, the result may include the display names for all the parents of the record and the point itself.

An easy to deal with this is by skipping any `Ref` values when processing the `disMacro`. Therefore the result is really `$equipRef`.

I admit this isn't a perfect solution. I'd argue the relative display names in `Haxall` are worse since you always need to know the parent. This is a pain when you want to render short display names from a list and not a tree control.