### PR TITLE
Adds locale specific formatting to HNum.toString

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "haystack-core",
-			"version": "2.0.48",
+			"version": "2.0.60",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
 				"@types/jest": "^29.5.2",

--- a/spec/core/HDict.spec.ts
+++ b/spec/core/HDict.spec.ts
@@ -181,7 +181,7 @@ describe('HDict', function (): void {
 		it('returns a human readable string', function (): void {
 			dict.set('nullVal', null)
 			expect(dict.toString()).toBe(
-				'{foo: foovalue, goo: 99.0, soo, nullVal: null}'
+				'{foo: foovalue, goo: 99, soo, nullVal: null}'
 			)
 		})
 	}) // #toString()

--- a/spec/core/HGrid.spec.ts
+++ b/spec/core/HGrid.spec.ts
@@ -469,7 +469,7 @@ type,val
 			it('returns a human readable string', function (): void {
 				grid.add({ test: 'me', number: 4, boo: true })
 				expect(grid.toString()).toEqual(
-					'[{foo: foo}, {test: me, number: 4.0, boo: true}]'
+					'[{foo: foo}, {test: me, number: 4, boo: true}]'
 				)
 			})
 		}) // #toString()

--- a/spec/core/HList.spec.ts
+++ b/spec/core/HList.spec.ts
@@ -570,7 +570,7 @@ describe('HList', function (): void {
 	describe('#toString()', function (): void {
 		it('returns a human readable string', function (): void {
 			list.push(null)
-			expect(list.toString()).toBe('[foovalue, 99.0, ✔, null]')
+			expect(list.toString()).toBe('[foovalue, 99, ✔, null]')
 		})
 	}) // #toString()
 

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -141,6 +141,14 @@ describe('HNum', function (): void {
 	}) //#unit()
 
 	describe('#toString()', function (): void {
+		it('returns the integer encoded as a string', function (): void {
+			expect(HNum.make(34).toString()).toBe('34')
+		})
+
+		it('returns the integer encoded as a string with precision', function (): void {
+			expect(HNum.make(34).toString(4)).toBe('34')
+		})
+
 		it('returns the number encoded as a string', function (): void {
 			expect(HNum.make(34.6).toString()).toBe('34.6')
 		})

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -7,6 +7,7 @@ import {
 	POSITIVE_INFINITY_ZINC,
 	NEGATIVE_INFINITY_ZINC,
 	NOT_A_NUMBER_ZINC,
+	DEFAULT_PRECISION,
 } from '../../src/core/HNum'
 import { Kind } from '../../src/core/Kind'
 import { HGrid } from '../../src/core/HGrid'
@@ -174,6 +175,63 @@ describe('HNum', function (): void {
 
 		it('returns NaN for not a number', function (): void {
 			expect(HNum.make(Number.NaN).toString()).toBe('NaN')
+		})
+
+		it('returns the number with U.S. locale formatting', () => {
+			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'en-us')).toBe(
+				'1,000.5'
+			)
+		})
+
+		it('returns the number with Great Britain locale formatting', () => {
+			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'en-gb')).toBe(
+				'1,000.5'
+			)
+		})
+
+		it('returns the number with Italys locale formatting', () => {
+			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'it-it')).toBe(
+				'1.000,5'
+			)
+		})
+
+		it('returns the number with Frances locale formatting', () => {
+			// Handle escaped space.
+			const formattedNumber = HNum.make(1000.5)
+				.toString(DEFAULT_PRECISION, 'fr-fr')
+				.replace(/\s/g, ' ')
+
+			expect(formattedNumber).toBe('1 000,5')
+		})
+
+		it('returns the number with Germanys locale formatting', () => {
+			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'de-de')).toBe(
+				'1.000,5'
+			)
+		})
+
+		it('returns the number with Spains locale formatting', () => {
+			expect(
+				HNum.make(10000.5).toString(DEFAULT_PRECISION, 'es-es')
+			).toBe('10.000,5')
+		})
+
+		it('returns the number with Netherlands locale formatting', () => {
+			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'nl-nl')).toBe(
+				'1.000,5'
+			)
+		})
+
+		it('returns the number with Netherlands (Belgium) locale formatting', () => {
+			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'nl-be')).toBe(
+				'1.000,5'
+			)
+		})
+
+		it('returns the number with Chinas locale formatting', () => {
+			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'zh-cn')).toBe(
+				'1,000.5'
+			)
 		})
 	}) // #toString()
 

--- a/spec/core/HNum.spec.ts
+++ b/spec/core/HNum.spec.ts
@@ -186,60 +186,84 @@ describe('HNum', function (): void {
 		})
 
 		it('returns the number with U.S. locale formatting', () => {
-			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'en-us')).toBe(
-				'1,000.5'
-			)
+			expect(
+				HNum.make(1000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'en-us',
+				})
+			).toBe('1,000.5')
 		})
 
 		it('returns the number with Great Britain locale formatting', () => {
-			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'en-gb')).toBe(
-				'1,000.5'
-			)
+			expect(
+				HNum.make(1000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'en-gb',
+				})
+			).toBe('1,000.5')
 		})
 
 		it('returns the number with Italys locale formatting', () => {
-			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'it-it')).toBe(
-				'1.000,5'
-			)
+			expect(
+				HNum.make(1000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'it-it',
+				})
+			).toBe('1.000,5')
 		})
 
 		it('returns the number with Frances locale formatting', () => {
 			// Handle escaped space.
 			const formattedNumber = HNum.make(1000.5)
-				.toString(DEFAULT_PRECISION, 'fr-fr')
+				.toString({ precision: DEFAULT_PRECISION, locale: 'fr-fr' })
 				.replace(/\s/g, ' ')
 
 			expect(formattedNumber).toBe('1 000,5')
 		})
 
 		it('returns the number with Germanys locale formatting', () => {
-			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'de-de')).toBe(
-				'1.000,5'
-			)
+			expect(
+				HNum.make(1000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'de-de',
+				})
+			).toBe('1.000,5')
 		})
 
 		it('returns the number with Spains locale formatting', () => {
 			expect(
-				HNum.make(10000.5).toString(DEFAULT_PRECISION, 'es-es')
+				HNum.make(10000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'es-es',
+				})
 			).toBe('10.000,5')
 		})
 
 		it('returns the number with Netherlands locale formatting', () => {
-			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'nl-nl')).toBe(
-				'1.000,5'
-			)
+			expect(
+				HNum.make(1000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'nl-nl',
+				})
+			).toBe('1.000,5')
 		})
 
 		it('returns the number with Netherlands (Belgium) locale formatting', () => {
-			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'nl-be')).toBe(
-				'1.000,5'
-			)
+			expect(
+				HNum.make(1000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'nl-be',
+				})
+			).toBe('1.000,5')
 		})
 
 		it('returns the number with Chinas locale formatting', () => {
-			expect(HNum.make(1000.5).toString(DEFAULT_PRECISION, 'zh-cn')).toBe(
-				'1,000.5'
-			)
+			expect(
+				HNum.make(1000.5).toString({
+					precision: DEFAULT_PRECISION,
+					locale: 'zh-cn',
+				})
+			).toBe('1,000.5')
 		})
 	}) // #toString()
 

--- a/spec/filter/FilterLexer.spec.ts
+++ b/spec/filter/FilterLexer.spec.ts
@@ -734,7 +734,7 @@ describe('FilterLexer', function (): void {
 
 				const value = lexer.nextToken()
 				expect(value.type).toBe(TokenType.number)
-				expect(value.toString()).toBe('1.0')
+				expect(value.toString()).toBe('1')
 
 				expect(TokenType[lexer.nextToken().type]).toBe(
 					TokenType[TokenType.rightBrace]

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -33,6 +33,21 @@ export const NEGATIVE_INFINITY_ZINC = '-INF'
 export const NOT_A_NUMBER_ZINC = 'NaN'
 
 /**
+ * Number formatting options.
+ */
+export interface NumberFormatOptions {
+	/**
+	 * The precision to use.
+	 */
+	precision: number
+
+	/**
+	 * The locale to use (i.e en-US).
+	 */
+	locale?: string
+}
+
+/**
  * Haystack number with units.
  */
 export class HNum implements HVal {
@@ -205,14 +220,21 @@ export class HNum implements HVal {
 	/**
 	 * Return the number as a readable string.
 	 *
-	 * @param precision Optional precision. Default is 1 decimal place.
-	 * @param locale Optional locale (i.e. en-US).
+	 * @param params The number format options. Can also be a number for precision
+	 * to support backwards compatibility.
 	 * @returns A string representation of the value.
 	 */
-	public toString(
-		precision: number = DEFAULT_PRECISION,
-		locale?: string
-	): string {
+	public toString(options?: NumberFormatOptions | number): string {
+		let precision = DEFAULT_PRECISION
+		let locale: string | undefined
+
+		if (typeof options === 'number') {
+			precision = options
+		} else if (options) {
+			precision = options.precision
+			locale = options.locale
+		}
+
 		if (this.value === Number.POSITIVE_INFINITY) {
 			return POSITIVE_INFINITY_ZINC
 		} else if (this.value === Number.NEGATIVE_INFINITY) {

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -208,7 +208,10 @@ export class HNum implements HVal {
 	 * @param precision Optional precision. Default is 1 decimal place.
 	 * @returns A string representation of the value.
 	 */
-	public toString(precision: number = DEFAULT_PRECISION): string {
+	public toString(
+		precision: number = DEFAULT_PRECISION,
+		locale?: string
+	): string {
 		if (this.value === Number.POSITIVE_INFINITY) {
 			return POSITIVE_INFINITY_ZINC
 		} else if (this.value === Number.NEGATIVE_INFINITY) {
@@ -216,7 +219,7 @@ export class HNum implements HVal {
 		} else if (isNaN(this.value)) {
 			return NOT_A_NUMBER_ZINC
 		} else {
-			const value = this.value.toLocaleString(/*locale*/ undefined, {
+			const value = this.value.toLocaleString(locale, {
 				style: 'decimal',
 				maximumFractionDigits: precision,
 				minimumFractionDigits: precision,

--- a/src/core/HNum.ts
+++ b/src/core/HNum.ts
@@ -206,6 +206,7 @@ export class HNum implements HVal {
 	 * Return the number as a readable string.
 	 *
 	 * @param precision Optional precision. Default is 1 decimal place.
+	 * @param locale Optional locale (i.e. en-US).
 	 * @returns A string representation of the value.
 	 */
 	public toString(
@@ -222,7 +223,7 @@ export class HNum implements HVal {
 			const value = this.value.toLocaleString(locale, {
 				style: 'decimal',
 				maximumFractionDigits: precision,
-				minimumFractionDigits: precision,
+				minimumFractionDigits: 0,
 			})
 
 			return this.#unitSymbol ? value + this.#unitSymbol : value


### PR DESCRIPTION
This PR provides the following functionality:
- Adds optional locale argument to HNum.toString method to [format in specific](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) locale.
- Adds Unit tests for specific locales