### PR TITLE
ZincReader: fix parsing of timezones containing "-"

### DIFF
--- a/spec/core/ZincReader.spec.ts
+++ b/spec/core/ZincReader.spec.ts
@@ -445,31 +445,42 @@ describe('ZincReader', function (): void {
 			})
 
 			it('parses a date time with timezone containing -', function (): void {
-				expect(
-					makeReader(
-						'2010-11-28T07:23:02.773-04:00 Port-au-Prince'
-					).readValue()
-				).toEqual(
-					HDateTime.make(
-						'2010-11-28T07:23:02.773-04:00 Port-au-Prince'
-					)
+				const parsedVal = makeReader(
+					'2010-11-28T07:23:02.773-04:00 Port-au-Prince'
+				).readValue()
+				const expectedVal = HDateTime.make(
+					'2010-11-28T07:23:02.773-04:00 Port-au-Prince'
+				)
+				expect(parsedVal).toEqual(expectedVal)
+				expect((parsedVal as HDateTime).timezone).toBe(
+					expectedVal.timezone
 				)
 			})
 
 			it('parses a date time with GMT-n timezone', function (): void {
-				expect(
-					makeReader(
-						'2025-06-12T15:22:11.518+02:00 GMT-2'
-					).readValue()
-				).toEqual(HDateTime.make('2025-06-12T15:22:11.518+02:00 GMT-2'))
+				const parsedVal = makeReader(
+					'2025-06-12T15:22:11.518+02:00 GMT-2'
+				).readValue()
+				const expectedVal = HDateTime.make(
+					'2025-06-12T15:22:11.518+02:00 GMT-2'
+				)
+				expect(parsedVal).toEqual(expectedVal)
+				expect((parsedVal as HDateTime).timezone).toBe(
+					expectedVal.timezone
+				)
 			})
 
 			it('parses a date time with GMT+n timezone', function (): void {
-				expect(
-					makeReader(
-						'2025-06-12T11:23:32.488-02:00 GMT+2'
-					).readValue()
-				).toEqual(HDateTime.make('2025-06-12T11:23:32.488-02:00 GMT+2'))
+				const parsedVal = makeReader(
+					'2025-06-12T11:23:32.488-02:00 GMT+2'
+				).readValue()
+				const expectedVal = HDateTime.make(
+					'2025-06-12T11:23:32.488-02:00 GMT+2'
+				)
+				expect(parsedVal).toEqual(expectedVal)
+				expect((parsedVal as HDateTime).timezone).toBe(
+					expectedVal.timezone
+				)
 			})
 		}) // date time
 

--- a/spec/core/ZincReader.spec.ts
+++ b/spec/core/ZincReader.spec.ts
@@ -443,6 +443,34 @@ describe('ZincReader', function (): void {
 					HDateTime.make('2010-11-28T07:23:02.773-08:00 Los_Angeles')
 				)
 			})
+
+			it('parses a date time with timezone containing -', function (): void {
+				expect(
+					makeReader(
+						'2010-11-28T07:23:02.773-04:00 Port-au-Prince'
+					).readValue()
+				).toEqual(
+					HDateTime.make(
+						'2010-11-28T07:23:02.773-04:00 Port-au-Prince'
+					)
+				)
+			})
+
+			it('parses a date time with GMT-n timezone', function (): void {
+				expect(
+					makeReader(
+						'2025-06-12T15:22:11.518+02:00 GMT-2'
+					).readValue()
+				).toEqual(HDateTime.make('2025-06-12T15:22:11.518+02:00 GMT-2'))
+			})
+
+			it('parses a date time with GMT+n timezone', function (): void {
+				expect(
+					makeReader(
+						'2025-06-12T11:23:32.488-02:00 GMT+2'
+					).readValue()
+				).toEqual(HDateTime.make('2025-06-12T11:23:32.488-02:00 GMT+2'))
+			})
 		}) // date time
 
 		describe('null', function (): void {
@@ -1323,6 +1351,84 @@ describe('ZincReader', function (): void {
 				})
 
 				const value = ZincReader.readValue(zinc)
+				expect(value && value.equals(grid)).toBe(true)
+			})
+
+			it('parses a grid with a datetime and timezone containing -', function (): void {
+				const zinc =
+					'<<ver:"3.0"\n' +
+					'val\n' +
+					'2025-06-12T08:24:25.631-04:00 Port-au-Prince\n' +
+					'>>'
+
+				const grid = HGrid.make({
+					columns: [
+						{
+							name: 'val',
+						},
+					],
+					rows: [
+						HDict.make({
+							val: HDateTime.make(
+								'2025-06-12T08:24:25.631-04:00 Port-au-Prince'
+							),
+						}),
+					],
+				})
+
+				const value = makeReader(zinc).readValue()
+				expect(value && value.equals(grid)).toBe(true)
+			})
+
+			it('parses a grid with a datetime and GMT-n timezone val', function (): void {
+				const zinc =
+					'<<ver:"3.0"\n' +
+					'val\n' +
+					'2025-06-12T14:54:00.88+02:00 GMT-2\n' +
+					'>>'
+
+				const grid = HGrid.make({
+					columns: [
+						{
+							name: 'val',
+						},
+					],
+					rows: [
+						HDict.make({
+							val: HDateTime.make(
+								'2025-06-12T14:54:00.88+02:00 GMT-2'
+							),
+						}),
+					],
+				})
+
+				const value = makeReader(zinc).readValue()
+				expect(value && value.equals(grid)).toBe(true)
+			})
+
+			it('parses a grid with a datetime and GMT+n timezone val', function (): void {
+				const zinc =
+					'<<ver:"3.0"\n' +
+					'val\n' +
+					'2025-06-12T14:54:00.88-02:00 GMT+2\n' +
+					'>>'
+
+				const grid = HGrid.make({
+					columns: [
+						{
+							name: 'val',
+						},
+					],
+					rows: [
+						HDict.make({
+							val: HDateTime.make(
+								'2025-06-12T14:54:00.88-02:00 GMT+2'
+							),
+						}),
+					],
+				})
+
+				const value = makeReader(zinc).readValue()
 				expect(value && value.equals(grid)).toBe(true)
 			})
 		}) // grid

--- a/src/core/ZincReader.ts
+++ b/src/core/ZincReader.ts
@@ -555,21 +555,9 @@ export class ZincReader {
 			while (
 				this.scanner.isLetter() ||
 				this.scanner.isDigit() ||
-				this.scanner.is('_')
-			) {
-				dateTime += this.scanner.current
-				this.scanner.consume()
-
-				while (this.scanner.isDigit()) {
-					dateTime += this.scanner.current
-					this.scanner.consume()
-				}
-			}
-
-			// handle GMT+xx or GMT-xx
-			if (
-				(this.scanner.is('+') || this.scanner.is('-')) &&
-				dateTime.endsWith('GMT')
+				this.scanner.is('_') || // Tz containing "_" (ex.: Los_Angeles)
+				this.scanner.is('-') || // GMT-n or tz containing "-" (ex.: Port-au-Prince)
+				this.scanner.is('+') // GMT+n
 			) {
 				dateTime += this.scanner.current
 				this.scanner.consume()


### PR DESCRIPTION
Fixing an error thrown trying to parse a grid, containing a datetime with one of the 3 non-GMT timezones having an hyphen (-) in their names:

"Blanc-Sablon", 
"Port-au-Prince", 
"Ust-Nera"

Example: 
```
ver:"3.0"
val
2025-06-12T10:06:06.584-04:00 Port-au-Prince
```

![image](https://github.com/user-attachments/assets/0d07033f-5355-4512-9f9d-b7a569c55f4e)

What was happening is that the parser stopped when it encountered the `-` char after `Port`, since it was not preceded by `GMT`. So the datetime was truncated to `2025-06-12T08:24:25.631-04:00 Port`.
Then, when the parser resumes, it would expect a comma or newline to delimit the value, instead it finds an hyphen, and throws an error.

When parsing a simple value instead of a grid, no error was thrown, but the timezone would still be truncated: `2025-06-12T08:24:25.631-04:00 Port`