### PR TITLE
add tag exclusion to relative filter generation

### DIFF
--- a/spec/filter/util.spec.ts
+++ b/spec/filter/util.spec.ts
@@ -87,5 +87,35 @@ describe('haystack', () => {
 				)
 			).toEqual('id == @id')
 		})
+
+		it('returns a haystack filter without excluded tags', () => {
+			expect(
+				makeRelativeHaystackFilter(
+					new HDict({
+						id: HRef.make('id'),
+						dis: 'an equip',
+						equip: HMarker.make(),
+						his: HMarker.make(),
+						aux: HMarker.make(),
+					})
+				)
+			).toEqual('equip and dis == "an equip"')
+		})
+
+		it('returns a haystack filter without custom excluded tags', () => {
+			expect(
+				makeRelativeHaystackFilter(
+					new HDict({
+						id: HRef.make('id'),
+						dis: 'an equip',
+						equip: HMarker.make(),
+						customTag: HMarker.make(),
+					}),
+					{
+						excludeTags: ['customTag'],
+					}
+				)
+			).toEqual('equip and dis == "an equip"')
+		})
 	}) // makeRelativeHaystackFilter()
 })

--- a/spec/filter/util.spec.ts
+++ b/spec/filter/util.spec.ts
@@ -7,6 +7,8 @@ import { HRef } from '../../src/core/HRef'
 import { makeRelativeHaystackFilter } from '../../src/filter/util'
 import { HMarker } from '../../src/core/HMarker'
 import { HStr } from '../../src/core/HStr'
+import { HSymbol } from '../../src/core/HSymbol'
+import { HNamespace } from '../../src/core/HNamespace'
 
 describe('haystack', () => {
 	describe('makeRelativeHaystackFilter()', () => {
@@ -102,6 +104,28 @@ describe('haystack', () => {
 			).toEqual('equip and dis == "an equip"')
 		})
 
+		it('returns a haystack filter without connPoint subtype tags', () => {
+			const mockNamespace = {
+				allSubTypesOf: () => [
+					HDict.make({ def: HSymbol.make('demoPoint') }),
+				],
+			} as unknown as HNamespace
+
+			expect(
+				makeRelativeHaystackFilter(
+					new HDict({
+						id: HRef.make('id'),
+						dis: 'an equip',
+						equip: HMarker.make(),
+						demoPoint: HMarker.make(),
+					}),
+					{
+						namespace: mockNamespace,
+					}
+				)
+			).toEqual('equip and dis == "an equip"')
+		})
+
 		it('returns a haystack filter without custom excluded tags', () => {
 			expect(
 				makeRelativeHaystackFilter(
@@ -112,7 +136,7 @@ describe('haystack', () => {
 						customTag: HMarker.make(),
 					}),
 					{
-						excludeTags: ['customTag'],
+						getExcludedTags: () => ['customTag'],
 					}
 				)
 			).toEqual('equip and dis == "an equip"')

--- a/src/filter/util.ts
+++ b/src/filter/util.ts
@@ -11,6 +11,22 @@ import { Kind } from '../core/Kind'
 import { HFilterBuilder } from '../filter/HFilterBuilder'
 
 /**
+ * Default list of tags to exclude from the relativization.
+ */
+export const RELATIVE_FILTER_EXCLUDED_TAGS = [
+	'aux',
+	'his',
+	'hisCollectCOV',
+	'hisCollectNA',
+	'hisTotalized',
+	'haystackPoint',
+	'bacnetPoint',
+	'axStatus',
+	'axAnnotated',
+	'demoPoint',
+]
+
+/**
  * Relativization options.
  */
 export interface RelativizeOptions {
@@ -23,6 +39,11 @@ export interface RelativizeOptions {
 	 * True (or undefined) if a point's kind should be used in the relativization.
 	 */
 	useKind?: boolean
+
+	/**
+	 * List of tags to exclude from the relativization.
+	 */
+	excludeTags?: string[]
 }
 
 /**
@@ -37,12 +58,17 @@ export function makeRelativeHaystackFilter(
 ): string {
 	const useDisplayName = options?.useDisplayName ?? true
 	const useKind = options?.useKind ?? true
+	const excludeTags = options?.excludeTags ?? RELATIVE_FILTER_EXCLUDED_TAGS
+	const excludedTagSet = new Set(excludeTags)
 
 	const builder = new HFilterBuilder()
 
 	// Build the marker tags.
 	for (const { name, value } of record) {
-		if (valueIsKind<HMarker>(value, Kind.Marker)) {
+		if (
+			valueIsKind<HMarker>(value, Kind.Marker) &&
+			!excludedTagSet.has(name)
+		) {
 			if (!builder.isEmpty()) {
 				builder.and()
 			}


### PR DESCRIPTION
This PR adds the possibility to provide a list of tags that will be excluded from the relative filter generation.
This can be useful when certain marker tags need to be avoided as they are not really part of what makes the relative filter relevant and would only restrict the filter usefulness.