### PR TITLE
Ensure column meta isn't encoded in JSON

### DIFF
--- a/spec/core/grid/GridJsonStore.spec.ts
+++ b/spec/core/grid/GridJsonStore.spec.ts
@@ -26,7 +26,6 @@ describe('GridJsonStore', () => {
 			cols: [
 				{
 					name: 'foo',
-					meta: {},
 				},
 				{
 					name: 'boo',
@@ -100,11 +99,9 @@ describe('GridJsonStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -125,11 +122,9 @@ describe('GridJsonStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -151,11 +146,9 @@ describe('GridJsonStore', () => {
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'boo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -179,11 +172,9 @@ describe('GridJsonStore', () => {
 						cols: [
 							{
 								name: 'foo',
-								meta: {},
 							},
 							{
 								name: 'boo',
-								meta: {},
 							},
 						],
 						rows: [

--- a/spec/core/grid/GridJsonStringStore.spec.ts
+++ b/spec/core/grid/GridJsonStringStore.spec.ts
@@ -27,11 +27,9 @@ describe('GridJsonStringStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -102,11 +100,9 @@ describe('GridJsonStringStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -127,11 +123,9 @@ describe('GridJsonStringStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -153,11 +147,9 @@ describe('GridJsonStringStore', () => {
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'boo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -176,15 +168,13 @@ describe('GridJsonStringStore', () => {
 			expect(store.toJSONString()).toBe(
 				JSON.stringify({
 					_kind: Kind.Grid,
-					meta: { ver: '4.0', foo: 'bar' },
+					meta: { foo: 'bar', ver: '4.0' },
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'boo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -208,11 +198,9 @@ describe('GridJsonStringStore', () => {
 						cols: [
 							{
 								name: 'foo',
-								meta: {},
 							},
 							{
 								name: 'boo',
-								meta: {},
 							},
 						],
 						rows: [

--- a/spec/core/grid/GridJsonUint8ArrayStore.spec.ts
+++ b/spec/core/grid/GridJsonUint8ArrayStore.spec.ts
@@ -28,11 +28,9 @@ describe('GridJsonUint8ArrayStore', () => {
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'boo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -104,11 +102,9 @@ describe('GridJsonUint8ArrayStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -129,11 +125,9 @@ describe('GridJsonUint8ArrayStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -155,11 +149,9 @@ describe('GridJsonUint8ArrayStore', () => {
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'boo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -178,15 +170,13 @@ describe('GridJsonUint8ArrayStore', () => {
 			expect(store.toJSONString()).toBe(
 				JSON.stringify({
 					_kind: Kind.Grid,
-					meta: { ver: '4.0', foo: 'bar' },
+					meta: { foo: 'bar', ver: '4.0' },
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'boo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -210,11 +200,9 @@ describe('GridJsonUint8ArrayStore', () => {
 						cols: [
 							{
 								name: 'foo',
-								meta: {},
 							},
 							{
 								name: 'boo',
-								meta: {},
 							},
 						],
 						rows: [

--- a/spec/core/grid/GridObjStore.spec.ts
+++ b/spec/core/grid/GridObjStore.spec.ts
@@ -88,11 +88,9 @@ describe('GridObjStore', () => {
 				cols: [
 					{
 						name: 'foo',
-						meta: {},
 					},
 					{
 						name: 'boo',
-						meta: {},
 					},
 				],
 				rows: [
@@ -114,11 +112,9 @@ describe('GridObjStore', () => {
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'boo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -142,11 +138,9 @@ describe('GridObjStore', () => {
 						cols: [
 							{
 								name: 'foo',
-								meta: {},
 							},
 							{
 								name: 'boo',
-								meta: {},
 							},
 						],
 						rows: [

--- a/spec/core/grid/HGrid.spec.ts
+++ b/spec/core/grid/HGrid.spec.ts
@@ -319,11 +319,9 @@ describe('HGrid', function (): void {
 					cols: [
 						{
 							name: 'foo',
-							meta: {},
 						},
 						{
 							name: 'goo',
-							meta: {},
 						},
 					],
 					rows: [
@@ -348,11 +346,9 @@ describe('HGrid', function (): void {
 						cols: [
 							{
 								name: 'foo',
-								meta: {},
 							},
 							{
 								name: 'goo',
-								meta: {},
 							},
 						],
 						rows: [
@@ -379,11 +375,9 @@ describe('HGrid', function (): void {
 							cols: [
 								{
 									name: 'foo',
-									meta: {},
 								},
 								{
 									name: 'goo',
-									meta: {},
 								},
 							],
 							rows: [
@@ -1587,10 +1581,10 @@ type,val
 				grid.reorderColumns(['a', 'b', 'c', 'd'])
 
 				expect(grid.toJSON().cols).toEqual([
-					{ name: 'a', meta: {} },
-					{ name: 'b', meta: {} },
-					{ name: 'c', meta: {} },
-					{ name: 'd', meta: {} },
+					{ name: 'a' },
+					{ name: 'b' },
+					{ name: 'c' },
+					{ name: 'd' },
 				])
 			})
 
@@ -1598,10 +1592,10 @@ type,val
 				grid.reorderColumns(['d', 'c', 'b', 'a'])
 
 				expect(grid.toJSON().cols).toEqual([
-					{ name: 'd', meta: {} },
-					{ name: 'c', meta: {} },
-					{ name: 'b', meta: {} },
-					{ name: 'a', meta: {} },
+					{ name: 'd' },
+					{ name: 'c' },
+					{ name: 'b' },
+					{ name: 'a' },
 				])
 			})
 		}) // #reorderColumns()

--- a/src/core/grid/GridJsonStore.ts
+++ b/src/core/grid/GridJsonStore.ts
@@ -40,6 +40,8 @@ export class GridJsonStore<DictVal extends HDict>
 		this.#metaJson = grid.meta
 		this.#columnsJson = grid.cols
 		this.#rowsJson = grid.rows
+
+		this.removeEmptyColumnMeta()
 	}
 
 	get version(): string {
@@ -65,6 +67,12 @@ export class GridJsonStore<DictVal extends HDict>
 				// adds the version number to the grid's meta data. We need to remove the version so
 				// comparisons (i.e. `equals`) still work as expected.
 				if (this.#meta.has(GRID_VERSION_NAME)) {
+					if (!this.#version) {
+						this.#version = this.#meta
+							.get(GRID_VERSION_NAME)
+							?.toString()
+					}
+
 					this.#meta.remove(GRID_VERSION_NAME)
 				}
 			} else {
@@ -123,24 +131,41 @@ export class GridJsonStore<DictVal extends HDict>
 
 	toJSON(): HaysonGrid {
 		// Return a new grid only with the parts of the grid that have changed.
+		const meta =
+			this.#meta || this.#version
+				? { ...this.meta.toJSON() }
+				: this.#metaJson ?? {}
+
+		// Ensure the grid meta is always present. It always needs to be present in
+		// the JSON encoding.
+		if (!meta[GRID_VERSION_NAME]) {
+			meta[GRID_VERSION_NAME] = this.version
+		}
+
 		return {
 			_kind: Kind.Grid,
-			meta:
-				this.#meta || this.#version
-					? {
-							[GRID_VERSION_NAME]: this.version,
-							...this.meta.toJSON(),
-					  }
-					: this.#metaJson ?? {},
+			meta,
 			cols: this.#columns
 				? this.#columns.map((column: GridColumn) => ({
 						name: column.name,
-						meta: column.meta.toJSON(),
+						meta: column.meta.isEmpty()
+							? undefined
+							: column.meta.toJSON(),
 				  }))
 				: this.#columnsJson ?? [],
 			rows: this.#rows
 				? this.#rows.map((row: DictVal): HaysonDict => row.toJSON())
 				: this.#rowsJson ?? [],
+		}
+	}
+
+	private removeEmptyColumnMeta() {
+		if (this.#columnsJson) {
+			for (const column of this.#columnsJson) {
+				if (column.meta && !Object.keys(column.meta).length) {
+					column.meta = undefined
+				}
+			}
 		}
 	}
 

--- a/src/core/grid/GridObjStore.ts
+++ b/src/core/grid/GridObjStore.ts
@@ -47,7 +47,7 @@ export class GridObjStore<DictVal extends HDict> implements GridStore<DictVal> {
 			},
 			cols: this.columns.map((column: GridColumn) => ({
 				name: column.name,
-				meta: column.meta.toJSON(),
+				meta: column.meta.isEmpty() ? undefined : column.meta.toJSON(),
 			})),
 			rows: this.rows.map((row: DictVal): HaysonDict => row.toJSON()),
 		}


### PR DESCRIPTION
Ensure empty column isn't encoded in JSON encoding. This unnecessarily creates objects in other systems that consume grids etc.

Also ensure a grid's meta always include the JSON version as per project haystack.